### PR TITLE
added some gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 logs/
-.DS_Store
-api/.DS_Store
-api/common/.DS_Store
+*.DS_Store
 frontends/web/package-lock.json


### PR DESCRIPTION
This branch adds some gitignores so that we don't have to worry about adding certain files to staging.
We were seeing a couple things:
- **.DS_Store** files
- **package-lock.json**

![image](https://user-images.githubusercontent.com/37890727/85435254-07b21d00-b53c-11ea-8ad3-cae9ebbf2fe9.png)
![image](https://user-images.githubusercontent.com/37890727/85435268-0c76d100-b53c-11ea-85c1-e6f39c0b98cc.png)
