### PR TITLE
layout changes for mobile, tablet and desktop

### DIFF
--- a/frontends/web/src/components/Rechart.js
+++ b/frontends/web/src/components/Rechart.js
@@ -51,11 +51,11 @@ const Rechart = ({
     }
   }
   return (
-    <ResponsiveContainer width="100%" height={height}>
+    <ResponsiveContainer width='100%' height={height}>
       <LineChart margin={{ left, right }} data={data}>
         <XAxis
           allowDecimals={false}
-          dataKey="name"
+          dataKey='name'
           padding={{ left: xAxisLeftPadding }}
           tick={{ fontSize }}
           tickLine={false}
@@ -70,11 +70,11 @@ const Rechart = ({
         />
         <Legend
           align='center'
-          layout="horizontal"
+          layout='horizontal'
           wrapperStyle={{
             fontSize,
           }}
-          verticalAlign="bottom"
+          verticalAlign='bottom'
         />
         {dataset.map((item, index) => (
           <Line
@@ -83,7 +83,7 @@ const Rechart = ({
             dot={{ fill: globalColors[index] }}
             stroke={globalColors[index]}
             strokeWidth={2}
-            type="linear"
+            type='linear'
           />
         ))}
       </LineChart>

--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -22,7 +22,7 @@ class TaskMainPage extends React.Component {
   render() {
     return (
       <Row>
-        <Col xs={12} sm={6}>
+        <Col xs={12} md={6}>
         <Card className="my-4">
           <Card.Header className="p-3 light-gray-bg">
             <h2 className="text-uppercase m-0 text-reset">Overall Model Leaderboard</h2>
@@ -55,7 +55,7 @@ class TaskMainPage extends React.Component {
           </Card.Body>
         </Card>
         </Col>
-        <Col xs={12} sm={6}>
+        <Col xs={12} md={6}>
         <Card className="my-4">
           <Card.Header className="p-3 light-gray-bg">
             <h2 className="text-uppercase m-0 text-reset">Trend</h2>


### PR DESCRIPTION
This PR puts chart below leaderboards on mobile. For tablet and desktop view, the leaderboards and charts sit on the same row with leaderboards on the left and chart on the right
# **Mobile**
![image](https://user-images.githubusercontent.com/37890727/86166584-ddc3a200-bac9-11ea-939c-d7fa1e5c58f9.png)

# **Tablet**
![image](https://user-images.githubusercontent.com/37890727/86166639-f59b2600-bac9-11ea-8225-759d8ddb2c59.png)

# **Desktop**
![image](https://user-images.githubusercontent.com/37890727/86166675-02b81500-baca-11ea-8fcb-e348cd5c3d0b.png)
