### PR TITLE
Updates to QA model server and interface

### DIFF
--- a/api/tools/populate_qa.py
+++ b/api/tools/populate_qa.py
@@ -1,0 +1,60 @@
+import json
+import sys
+import os
+import secrets
+import codecs
+
+fname = '20200701-1806-harderqs-passages.jsonl'
+if not os.path.exists(fname):
+    os.system(f'wget http://cdn.cybermaxcreations.com/qa/{fname}')
+
+contexts = {'1': [], '2': []}
+for n in contexts.keys():
+    fpath = os.path.join(fname)
+    print(fpath)
+    this_contexts = [json.loads(l) for l in codecs.open(fpath, 'r', 'utf8')]
+    this_contexts = [{
+        'context': c['passage'],
+        'metadata_json': json.dumps({
+            'id': c['id'],
+            'title': c['title'],
+            'data_split': c['ref'],
+            'source': 'squad_v1.1'
+        })
+    } for c in this_contexts]
+    contexts[n] = this_contexts
+
+print({k:len(contexts[k]) for k in contexts.keys()})
+
+sys.path.append('..')
+from models.context import ContextModel, Context
+from models.task import TaskModel, Task
+from models.round import RoundModel, Round
+
+
+tm = TaskModel()
+task = tm.getByShortName('QA')
+rm = RoundModel()
+rounds = [x.to_dict()['rid'] for x in rm.getByTid(task.id)]
+print(rounds)
+
+# Connect to the task model database session
+dbs = tm.dbs
+
+for rid in contexts.keys():
+    if rid not in rounds:
+        round = Round(task=task, rid=int(rid), secret=secrets.token_hex(), url='https://TBD')
+        dbs.add(round)
+        dbs.flush()
+    else:
+        round = rm.getByTidAndRid(task.id, int(rid))
+
+    for context in contexts[rid]:
+        print(task.id, rid, context, task, round)
+        tags = 'AQA|AQA'+rid
+        c = Context(round=round, context=context['context'], metadata_json=context['metadata_json']) #, tags=tags)  # Seems like tags have been removed from the db
+        print(c)
+        dbs.add(c)
+        dbs.flush()
+
+dbs.commit()

--- a/frontends/web/src/containers/CreateInterface.js
+++ b/frontends/web/src/containers/CreateInterface.js
@@ -34,7 +34,7 @@ class ContextInfo extends React.Component {
       <>
         <TokenAnnotator
           className="mb-1 p-3 light-gray-bg"
-          tokens={this.props.text.split(" ")}
+          tokens={this.props.text.split(/\b/)}
           value={this.props.answer}
           onChange={this.props.updateAnswer}
           getSpan={(span) => ({
@@ -229,7 +229,9 @@ class CreateInterface extends React.Component {
         var answer_text = "";
         if (this.state.answer.length > 0) {
           var last_answer = this.state.answer[this.state.answer.length - 1];
-          var answer_text = last_answer.tokens.join(" ");
+          var answer_text = last_answer.tokens.join("");  // NOTE: no spaces required as tokenising by word boundaries
+          // Update the target with the answer text since this is defined by the annotator in QA (unlike NLI)
+          this.setState({ target: answer_text });
         }
       } else {
         var answer_text = null;

--- a/modelservers/qa/run_round1.py
+++ b/modelservers/qa/run_round1.py
@@ -141,7 +141,7 @@ async def handle_submit_post(request):
         model_preds = await get_model_preds([example])
         model_pred = model_preds[0]
         response['text'] = model_pred['text']
-        response['prob'] = max(1.0, min(0.0, model_pred['model_conf']))  # this is what the frontend expects
+        response['prob'] = max(0.0, min(1.0, model_pred['model_conf']))  # this is what the frontend expects
 
         # Evaluate the model prediction against the human answer
         human_ans = str(post_data['answer']).strip()


### PR DESCRIPTION
Updated setting state of target for QA (so that it is logged accordingly)
Do QA tokenisation by word boundaries using regex
Fixed bug in QA model confidence limits
Create script to populate contexts with QA data for rounds 1 and 2