### PR TITLE
[fix] Error in case log folder is not there by default

### DIFF
--- a/api/common/logging.py
+++ b/api/common/logging.py
@@ -5,12 +5,14 @@
 import bottle
 
 import logging
+import os
 
 from datetime import datetime
 
 def init_logger(mode):
     logger = logging.getLogger('dynabench')
     logger.setLevel(logging.INFO)
+    os.makedirs("../logs", exist_ok=True)
     file_handler = logging.FileHandler(f'../logs/dynabench-server-{mode}.log')
     formatter = logging.Formatter('%(msg)s')
     file_handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
Running server for first time throws an error if logs folder is not there. This creates the log folder if it not there by default.