### PR TITLE
Set a default algorithm in example config

### DIFF
--- a/api/common/config.py.example
+++ b/api/common/config.py.example
@@ -5,7 +5,7 @@
 config = { \
         'jwtsecret': '',
         'jwtexp': 15*60, # in seconds (5 minutes)
-        'jwtalgo': '',
+        'jwtalgo': 'HS256',
         'cookie_secret': '',
         'refreshexp': 90, # in days
         'db_host': 'localhost', # Change as required (aws rds)


### PR DESCRIPTION
We talked about making this algorithm setting the default in the example config. The website doesn't work when it is not specified.