### PR TITLE
Fixed the bug causing the outdated model warning to persist after the current round is reselected

### DIFF
--- a/frontends/web/src/containers/CreateInterface.js
+++ b/frontends/web/src/containers/CreateInterface.js
@@ -337,7 +337,7 @@ class ResponseInfo extends React.Component {
             })}
         </div>
       </>;
-    } 
+    }
     return (
       <Card
         className={classNames}
@@ -472,7 +472,7 @@ class CreateInterface extends React.Component {
   }
 
   updateSelectedRound(e) {
-    const selected = e.target.getAttribute('index');
+    const selected = parseInt(e.target.getAttribute('index'));
     if (selected != this.state.task.selected_round) {
       this.context.api.getTaskRound(this.state.task.id, selected)
         .then((result) => {
@@ -763,7 +763,7 @@ class CreateInterface extends React.Component {
     function renderSwitchContextTooltip(props) {
       return renderTooltip(props, "Don't like this context? Try another one.");
     }
-  
+
     return (
       <OverlayProvider initiallyHide={true}>
         <BadgeOverlay


### PR DESCRIPTION
The problem was that the code relied on the selected round to be an integer to compare it to the current round. But the selected round was updated to be a string, causing it to never be the same as the current round.