### PR TITLE
Fixed badge awarded time displaying as incorrect if the user is not utc

### DIFF
--- a/frontends/web/src/containers/BadgeGrid.js
+++ b/frontends/web/src/containers/BadgeGrid.js
@@ -25,7 +25,7 @@ const BadgeGrid = (props) => {
               delay={{ show: 250, hide: 400 }}
               overlay={(props) => <Tooltip {...props}>
                 {name}<br/>
-                <Moment utc fromNow>{awarded}</Moment>
+                <Moment fromNow>{awarded}</Moment>
                 </Tooltip>}
             >
               <img src={"/badges/"+name+".png"} style={{width: 50, marginBottom: 10, cursor: 'pointer'}} />


### PR DESCRIPTION
The issue is seen when hovering a mouse over the user's stats and badges.