### PR TITLE
simple remote mturk qualification query and grant script

### DIFF
--- a/annotators/set_mturk_qualification.py
+++ b/annotators/set_mturk_qualification.py
@@ -25,6 +25,7 @@ e.g.,
 
 from mephisto.core.local_database import LocalMephistoDB
 
+
 db = LocalMephistoDB()
 reqs = db.find_requesters(provider_type="mturk")
 names = [r.requester_name for r in reqs]
@@ -42,30 +43,32 @@ restricted_pool_qual_id = input("Provide the qualification id: ")
 
 update_or_query = input("(g)rant or (q)uery? : ")
 if update_or_query == "g":
-    user_id = input("Provide the worker id that you want to add into the qualification: ")
+    user_id = input(
+        "Provide the worker id that you want to add into the qualification: "
+    )
     restricted_jsons = mturk_client.associate_qualification_with_worker(
-                                            QualificationTypeId=restricted_pool_qual_id,
-                                            SendNotification=True,
-                                            IntegerValue=0,
-                                            WorkerId=user_id
-                                        )
+        QualificationTypeId=restricted_pool_qual_id,
+        SendNotification=True,
+        IntegerValue=0,
+        WorkerId=user_id,
+    )
 elif update_or_query == "q":
-    restricted_pool = set([])
+    restricted_pool = set()
     pagination_token = None
     while 1:
         if pagination_token:
             restricted_jsons = mturk_client.list_workers_with_qualification_type(
-                                                QualificationTypeId=restricted_pool_qual_id,
-                                                Status='Granted',
-                                                MaxResults=100,
-                                                NextToken=pagination_token
-                                            )
+                QualificationTypeId=restricted_pool_qual_id,
+                Status="Granted",
+                MaxResults=100,
+                NextToken=pagination_token,
+            )
         else:
             restricted_jsons = mturk_client.list_workers_with_qualification_type(
-                                                QualificationTypeId=restricted_pool_qual_id,
-                                                Status='Granted',
-                                                MaxResults=100
-                                            )
+                QualificationTypeId=restricted_pool_qual_id,
+                Status="Granted",
+                MaxResults=100,
+            )
         if len(restricted_jsons["Qualifications"]) == 0:
             break
         pagination_token = restricted_jsons["NextToken"]
@@ -78,4 +81,4 @@ elif update_or_query == "q":
 # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/mturk.html#id48
 else:
     print("ERR: invalid inputs")
-    assert(False)
+    assert False


### PR DESCRIPTION
Description:
> This script is a starting script to manipulate a remote existing or new qualification.
> You can both grant or query current remote qualification that can use to restrict
> users to preview and accept your tasks, which is different from LocalDB qualifications.

> This script is helpful if you want to restrict your HITs to a pool of turkers. You can create
> a qualification and put all turkers into that qualification by assigning them value. And add
> this qualification into your task *.json config file and util.py. Simply add your qualification 
> name to ``qualifications`` list would work.

Test Done:
> Local test with own user worker and requester account.