### PR TITLE
Fix a bug to correctly filter the example based on tags.

### DIFF
--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -90,7 +90,7 @@ def get_random_example(credentials, tid, rid):
         )
     else:
         example = em.getRandom(
-            round.id, validate_non_fooling, num_matching_validations, n=1
+            round.id, validate_non_fooling, num_matching_validations, n=1, tags=tags
         )
     if not example:
         bottle.abort(500, f"No examples available ({round.id})")


### PR DESCRIPTION
The current `getRandomExample` API can not filter the examples based on tags in `turk` mode. Made a quick fix on that. We will probably also need to re-launch the server.