### PR TITLE
[fix] pyjwt upgrade fix incommpatibilities

### DIFF
--- a/api/common/auth.py
+++ b/api/common/auth.py
@@ -52,9 +52,9 @@ def get_payload(token):
         payload = jwt.decode(
             token, app.config["jwtsecret"], algorithms=[app.config["jwtalgo"]]
         )
-    except jwt.ExpiredSignature:
+    except jwt.ExpiredSignatureError:
         bottle.abort(401, {"code": "token_expired", "description": "token is expired"})
-    except jwt.DecodeError as e:
+    except jwt.InvalidSignatureError as e:
         bottle.abort(401, {"code": "token_invalid", "description": e.message})
     return payload
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp
 bottle
 cheroot
-PyJWT
+PyJWT>=2.0.0
 numpy
 pymysql
 sagemaker


### PR DESCRIPTION
From the [ChangeLog](https://github.com/jpadilla/pyjwt/blob/3993ce1d3503b58cf74699a89ba9e5c18ef9b556/CHANGELOG.rst#L75):

* Dropped deprecated errors (changed from v2.0.0)
   * Removed ExpiredSignature, InvalidAudience, and InvalidIssuer. Use ExpiredSignatureError, InvalidAudienceError, and InvalidIssuerError instead.
* An invalid signature now raises an InvalidSignatureError instead of DecodeError #316 (changed from v1.6.0)


