### PR TITLE
[feat] Global users list

### DIFF
--- a/api/common/helpers.py
+++ b/api/common/helpers.py
@@ -471,3 +471,24 @@ def read_file_content(file_obj, max_limit):
         buf = file_obj.read(BUF_SIZE)
 
     return b"".join(data_blocks)
+
+
+def construct_user_board_response_json(query_result, total_count=0):
+    list_objs = []
+    # converting query result into json object
+    for result in query_result:
+        obj = {}
+        obj["uid"] = result[0]
+        obj["username"] = result[1]
+        obj["avatar_url"] = result[2] if result[2] is not None else ""
+        obj["count"] = int(result[3])
+        obj["MER"] = str(round(result[4] * 100, 2))
+        obj["total"] = str(result[3]) + "/" + str(result[5])
+        list_objs.append(obj)
+    if list_objs:
+        # total_count = query_result[0][len(query_result[0]) - 1]
+        resp_obj = {"count": total_count, "data": list_objs}
+        return json_encode(resp_obj)
+    else:
+        resp_obj = {"count": 0, "data": []}
+        return json_encode(resp_obj)

--- a/api/controllers/tasks.py
+++ b/api/controllers/tasks.py
@@ -53,7 +53,7 @@ def get_user_leaderboard(tid):
         query_result, total_count = e.getUserLeaderByTidAndRid(
             tid=tid, n=limit, offset=offset
         )
-        return construct_user_board_response_json(
+        return util.construct_user_board_response_json(
             query_result=query_result, total_count=total_count
         )
     except Exception as ex:
@@ -75,7 +75,7 @@ def get_leaderboard_by_task_and_round(tid, rid):
         query_result, total_count = e.getUserLeaderByTidAndRid(
             tid=tid, rid=rid, n=limit, offset=offset
         )
-        return construct_user_board_response_json(
+        return util.construct_user_board_response_json(
             query_result=query_result, total_count=total_count
         )
     except Exception as ex:
@@ -210,27 +210,6 @@ def update_task_settings(credentials, tid):
     except Exception:
         logger.error(f"Error updating task settings {tid}: {task}")
         bottle.abort(500, {"error": str(task)})
-
-
-def construct_user_board_response_json(query_result, total_count=0):
-    list_objs = []
-    # converting query result into json object
-    for result in query_result:
-        obj = {}
-        obj["uid"] = result[0]
-        obj["username"] = result[1]
-        obj["avatar_url"] = result[2] if result[2] is not None else ""
-        obj["count"] = int(result[3])
-        obj["MER"] = str(round(result[4] * 100, 2))
-        obj["total"] = str(result[3]) + "/" + str(result[5])
-        list_objs.append(obj)
-    if list_objs:
-        # total_count = query_result[0][len(query_result[0]) - 1]
-        resp_obj = {"count": total_count, "data": list_objs}
-        return util.json_encode(resp_obj)
-    else:
-        resp_obj = {"count": 0, "data": []}
-        return util.json_encode(resp_obj)
 
 
 @bottle.get("/tasks/<tid:int>/models")

--- a/api/controllers/users.py
+++ b/api/controllers/users.py
@@ -11,6 +11,7 @@ import common.helpers as util
 import common.mail_service as mail
 from common.logging import logger
 from models.badge import BadgeModel
+from models.example import ExampleModel
 from models.model import ModelModel
 from models.notification import NotificationModel
 from models.user import UserModel
@@ -23,6 +24,21 @@ def users():
     u = UserModel()
     users = u.list()
     return util.json_encode(users)
+
+
+@bottle.get("/users/leaderboard")
+def get_users_leaderboard():
+    e = ExampleModel()
+    limit, offset = util.get_limit_and_offset_from_request()
+    try:
+        examples = e.getAll()
+        query_result, total_count = e.getUsers(examples, n=limit, offset=offset)
+        return util.construct_user_board_response_json(
+            query_result=query_result, total_count=total_count
+        )
+    except Exception as ex:
+        logger.exception(f"User leader board data loading failed: {ex}")
+        bottle.abort(400, f"Leaderboard fetch failed. {ex}")
 
 
 @bottle.get("/users/<id:int>")

--- a/api/models/example.py
+++ b/api/models/example.py
@@ -192,6 +192,19 @@ class ExampleModel(BaseModel):
         else:
             examples = self.getByTidAndRid(tid, rid)
 
+        return self.getUsers(
+            examples, num_matching_validations, n, offset, min_cnt, downstream
+        )
+
+    def getUsers(
+        self,
+        examples,
+        num_matching_validations=3,
+        n=5,
+        offset=0,
+        min_cnt=0,
+        downstream=False,
+    ):
         # Form and return a list of lists for each user, where a sublist contains:
         # 1. the user id
         # 2. the username
@@ -281,6 +294,18 @@ class ExampleModel(BaseModel):
             return (result_list[n * offset : n * (offset + 1)], len(result_list))
         return result_list
 
+    def getAll(self):
+        try:
+            return (
+                self.dbs.query(Example)
+                .join(Context, Example.cid == Context.id)
+                .join(Round, Context.r_realid == Round.id)
+                .all()
+            )
+        except db.orm.exc.NoResultFound as e:
+            print(f"Exception: {e.description}")
+            return False
+
     def getByTid(self, tid):
         try:
             return (
@@ -290,7 +315,8 @@ class ExampleModel(BaseModel):
                 .filter(Round.tid == tid)
                 .all()
             )
-        except db.orm.exc.NoResultFound:
+        except db.orm.exc.NoResultFound as e:
+            print(f"Exception: {e.description}")
             return False
 
     def getByTidAndRid(self, tid, rid):
@@ -303,7 +329,8 @@ class ExampleModel(BaseModel):
                 .filter(Round.rid == rid)
                 .all()
             )
-        except db.orm.exc.NoResultFound:
+        except db.orm.exc.NoResultFound as e:
+            print(f"Exception: {e.description}")
             return False
 
     def getByTidAndRidWithValidationIds(self, tid, rid):
@@ -327,7 +354,8 @@ class ExampleModel(BaseModel):
                 .group_by(Example.id)
             )
             return validations_query.union(no_validations_query).all()
-        except db.orm.exc.NoResultFound:
+        except db.orm.exc.NoResultFound as e:
+            print(f"Exception: {e.description}")
             return False
 
     def getRandom(

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -197,14 +197,20 @@ export default class ApiService {
     });
   }
 
-  getOverallUserLeaderboard(taskId, round, limit, offset) {
+  getUserLeaderboardForTask(taskId, round, limit=10, offset=0) {
     const url =
       round === "overall"
-        ? `/users?limit=${limit || 10}&offset=${offset || 0}`
-        : `/rounds/${round}/users?limit=${limit || 10}&offset=${offset || 0}`;
+        ? `/users?limit=${limit}&offset=${offset}`
+        : `/rounds/${round}/users?limit=${limit}&offset=${offset}`;
     return this.fetch(`${this.domain}/tasks/${taskId}${url}`, {
       method: "GET",
     });
+  }
+
+  getUsersLeaderboard(limit=20, offset=0) {
+    return this.fetch(`${this.domain}/users/leaderboard?limit=${limit}&offset=${offset}`, {
+      method: "GET",
+    })
   }
 
   getUser(id, badges=false) {

--- a/frontends/web/src/containers/App.js
+++ b/frontends/web/src/containers/App.js
@@ -16,6 +16,7 @@ import RegisterPage from "./RegisterPage";
 import ProfilePage from "./ProfilePage";
 import AboutPage from "./AboutPage";
 import TaskPage from "./TaskPage";
+import UsersPage from "./UsersPage";
 import ContactPage from "./ContactPage";
 import TermsPage from "./TermsPage";
 import DataPolicyPage from "./DataPolicyPage";
@@ -156,6 +157,11 @@ class App extends React.Component {
                   <NavDropdown title="Tasks" id="basic-nav-dropdown">
                     {NavItems}
                   </NavDropdown>
+                  <Nav.Item>
+                    <Nav.Link as={Link} to="/users">
+                      Users
+                    </Nav.Link>
+                  </Nav.Item>
                 </Nav>
                 <Nav className="justify-content-end">
                   {this.state.user.id ? (
@@ -217,6 +223,7 @@ class App extends React.Component {
             <div id="content">
               <Switch>
                 <Route path="/about" component={AboutPage} />
+                <Route path="/users" component={UsersPage} />
                 <Route path="/contact" component={ContactPage} />
                 <Route path="/termsofuse" component={TermsPage} />
                 <Route path="/datapolicy" component={DataPolicyPage} />

--- a/frontends/web/src/containers/OverallUserLeaderboard.js
+++ b/frontends/web/src/containers/OverallUserLeaderboard.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
+import { Avatar } from "../components/Avatar/Avatar";
+import { Link } from "react-router-dom";
+import { Table } from "react-bootstrap";
+
+export const OverallUserLeaderBoard = (props) => {
+    return (
+      <Table hover bordered striped>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th className="text-right">Verified MER</th>
+            <th className="text-right pr-4">Totals</th>
+          </tr>
+        </thead>
+        <tbody>
+          {props.data.map((data) => {
+            return (
+              <tr key={data.uid}>
+                <td>
+                  <Avatar
+                    avatar_url={data.avatar_url}
+                    username={data.username}
+                    isThumbnail={true}
+                    theme="blue"
+                  />
+                  <Link to={`/users/${data.uid}#profile`} className="btn-link">
+                    {data.username}
+                  </Link>
+                </td>
+                <td className="text-right">{data.MER}%</td>
+                <td className="text-right pr-4">{data.total}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    );
+  };

--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -28,9 +28,9 @@ import { Link } from "react-router-dom";
 import { Formik } from "formik";
 import UserContext from "./UserContext";
 import { LineRechart } from "../components/Rechart";
-import { Avatar } from "../components/Avatar/Avatar";
 import Moment from "react-moment";
 import DragAndDrop from "../components/DragAndDrop/DragAndDrop";
+import { OverallUserLeaderBoard } from "./OverallUserLeaderboard";
 import {
   OverlayProvider,
   Annotation,
@@ -301,41 +301,6 @@ const OverallModelLeaderBoard = (props) => {
   );
 };
 
-const OverallUserLeaderBoard = (props) => {
-  return (
-    <Table hover className="mb-0">
-      <thead>
-        <tr>
-          <th>User</th>
-          <th className="text-right">Verified MER</th>
-          <th className="text-right pr-4">Totals</th>
-        </tr>
-      </thead>
-      <tbody>
-        {props.data.map((data) => {
-          return (
-            <tr key={data.uid}>
-              <td>
-                <Avatar
-                  avatar_url={data.avatar_url}
-                  username={data.username}
-                  isThumbnail={true}
-                  theme="blue"
-                />
-                <Link to={`/users/${data.uid}#profile`} className="btn-link">
-                  {data.username}
-                </Link>
-              </td>
-              <td className="text-right">{data.MER}%</td>
-              <td className="text-right pr-4">{data.total}</td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </Table>
-  );
-};
-
 class RoundDescription extends React.Component {
   constructor(props) {
     super(props);
@@ -501,7 +466,7 @@ class TaskPage extends React.Component {
 
   fetchOverallUserLeaderboard(page) {
     this.context.api
-      .getOverallUserLeaderboard(
+      .getUserLeaderboardForTask(
         this.state.taskId,
         this.props.location.hash.replace("#", ""),
         this.state.pageLimit,

--- a/frontends/web/src/containers/UsersPage.js
+++ b/frontends/web/src/containers/UsersPage.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from "react";
+import { OverallUserLeaderBoard } from "./OverallUserLeaderboard";
+import {
+  Card,
+  Pagination,
+} from "react-bootstrap";
+import UserContext from "./UserContext";
+
+
+class UsersPage extends React.Component {
+  static contextType = UserContext;
+  constructor(props) {
+    super(props);
+    this.state = {
+      userLeaderBoardData: [],
+      isEndOfModelLeaderPage: true,
+      userLeaderBoardPage: 0,
+      pageLimit: 10,
+    }
+  }
+
+  componentDidMount() {
+    this.fetchUserLeaderboardPage(0)
+  }
+
+  fetchUserLeaderboardPage(page) {
+    this.context.api
+    .getUsersLeaderboard(
+      this.state.pageLimit,
+      page
+    )
+    .then((result) => {
+      const isEndOfPage = (page + 1) * this.state.pageLimit >= result.count;
+      this.setState({
+        isEndOfUserLeaderPage: isEndOfPage,
+        userLeaderBoardData: result.data,
+      });
+  }, (error) => {
+    console.log(error);
+  });
+  }
+
+  paginate = (state) => {
+    var isNext = (state === "next")
+    var userLeaderBoardPage = isNext ? this.state.userLeaderBoardPage + 1 : this.state.userLeaderBoardPage - 1
+    this.setState(
+      {
+        userLeaderBoardPage: userLeaderBoardPage
+      },
+      () => {
+        this.fetchUserLeaderboardPage(this.state.userLeaderBoardPage);
+      }
+    );
+  };
+
+  render() {
+    return (
+      <Card className="my-4">
+        <Card.Header className="p-3 light-gray-bg">
+          <h2 className="text-uppercase m-0 text-reset">
+            Global Users Leaderboard
+          </h2>
+        </Card.Header>
+        <Card.Body className="p-0 leaderboard-container">
+          <OverallUserLeaderBoard
+            data={this.state.userLeaderBoardData}
+          />
+        </Card.Body>
+        <Card.Footer className="text-center">
+          <Pagination className="mb-0 float-right" size="sm">
+            <Pagination.Item
+              disabled={!this.state.userLeaderBoardPage}
+              onClick={() => this.paginate("previous")}
+            >
+              Previous
+            </Pagination.Item>
+            <Pagination.Item
+              disabled={this.state.isEndOfUserLeaderPage}
+              onClick={() => this.paginate("next")}
+            >
+              Next
+            </Pagination.Item>
+          </Pagination>
+        </Card.Footer>
+      </Card>
+    )
+  }
+}
+
+export default UsersPage;


### PR DESCRIPTION
* My guess: @douwekiela wants this feature to see that he is number one in the global user list (which has 21 people!)
* I am really not good at UI, so apologies if this is ugly
* Ideally I do not get generic requests/reviews such as "Please make this more beautiful" - because I really do not know how. (I did invest time in this, but I found this isn't really in my genes). I can make components readable, but not beautiful. 😢 
* But specific requests on the UI such as "bigger fonts etc", I can make changes.
* I am not smart enough to understand the code for MER... so I tried my best to reuse what is available.
* `OverallUserLeaderBoard` refactored to be a component itself to be reused in two locations
* Made pagination work (page limit set to 10 for now, unless you tell me a different number)
* Some minor refactors...

Screenshot:
<img width="1451" alt="Screen Shot 2021-01-27 at 8 26 48 PM" src="https://user-images.githubusercontent.com/1545487/106099377-a90ade00-60de-11eb-9986-8f45aba3d516.png">
