### PR TITLE
[fix] Fix CUDA docker, deploy script changes for VQA

### DIFF
--- a/torchserve/configs/config_vqa_1_1.json
+++ b/torchserve/configs/config_vqa_1_1.json
@@ -9,5 +9,6 @@
     "gateway_url": "https://fhcxpbltv0.execute-api.us-west-1.amazonaws.com/predict",
     "sagemaker_role": "AmazonSageMaker-ExecutionRole-20200629T161149",
     "redeploy": true,
-    "instance_type": "ml.g4dn.xlarge"
+    "instance_type": "ml.g4dn.xlarge",
+    "checkpoint_name": "movie_mcan_final.pth"
 }

--- a/torchserve/deploy.py
+++ b/torchserve/deploy.py
@@ -162,6 +162,9 @@ def setup_sagemaker_env(config):
     if config["task"] == "nli" and config["round_id"] == 4:
         print("NLI round 4, using custom Docker")
         env["registry_name"] = "torchserve2"
+    elif config["task"] == "vqa":
+        print("VQA task, using custom Docker")
+        env["registry_name"] = "torchserve_vqa"
     else:
         env["registry_name"] = "torchserve"
     env["prefix"] = "torchserve"
@@ -203,7 +206,8 @@ def load_config(config_path):
     config["mars_path"] = f"mars"
     config["model_dir"] = f"{config['task_path']}/r{round_id}/r{round_id}_{model_no}/"
     config["model_path"] = os.path.join(
-        config["model_dir"], f"pytorch_model{config['extension']}"
+        config["model_dir"],
+        config.get("checkpoint_name", f"pytorch_model{config['extension']}"),
     )
     config["round_path"] = f"{config['task_path']}/r{round_id}"
 

--- a/torchserve/dockerfiles/Dockerfile.cuda
+++ b/torchserve/dockerfiles/Dockerfile.cuda
@@ -14,8 +14,9 @@ RUN apt-get update && \
     curl \
     vim \
     git \
+    wget \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
-
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
@@ -42,6 +43,12 @@ RUN pip install --no-cache-dir psutil
 
 RUN pip install transformers==3.4.0
 RUN pip install git+git://github.com/facebookresearch/mmf.git@079f71d8c217001fd0a88c2efd0cac51ad4b3aef
+
+# Download and unzip glove for mmf
+RUN mkdir -p /root/.cache/torch/mmf
+RUN wget http://nlp.stanford.edu/data/glove.6B.zip -P /root/.cache/torch/mmf/
+RUN unzip /root/.cache/torch/mmf/glove.6B.zip -d /root/.cache/torch/mmf/
+RUN rm /root/.cache/torch/mmf/glove.6B.zip
 
 RUN pip install torchserve torch-model-archiver
 


### PR DESCRIPTION
- Adds unzipped glove vectors to docker to save worker memory timeout issue during download/unzip in Sagemaker
- Modifies `torchserve/deploy.py` script to accommodate VQA deployment


Test Plan:

- Deployed the model and verified model is working in Sagemaker