### PR TITLE
logout user if their token cannot be refreshed

### DIFF
--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -426,6 +426,7 @@ export default class ApiService {
         },
         function () {
           console.log("Could not refresh token (loggedIn)");
+          localStorage.removeItem("id_token");
           //window.location.href = '/login';
           return false;
         }
@@ -527,6 +528,7 @@ export default class ApiService {
         (res) => {
           console.log("Could not refresh token (fetch)");
           var error = new Error("Could not refresh token");
+          localStorage.removeItem("id_token");
           //window.location.href = '/login';
           throw error;
         }


### PR DESCRIPTION
For #255

Based on the behavior of the production website, it seems that the issue could be caused by a mismatch between an expired token and refresh_token in the users table. At least, this is the only way that I could think to reproduce the faulty behavior in my local dev environment. In this case, I'm not sure how we could refresh the token. This pull request does the next best thing, which is logging the user out completely if the token cannot be refreshed. I'm open to suggestions, though - I'm not super familiar with this part of the codebase.