### PR TITLE
[fix] Fix VQA handler prediction output to be float instead of Tensor

### DIFF
--- a/torchserve/tasks/vqa/r1/handler.py
+++ b/torchserve/tasks/vqa/r1/handler.py
@@ -122,7 +122,7 @@ class MMFMovieMcanVQAHandler(BaseHandler):
             max_ind = outputs["scores"].argmax()
             max_prob = outputs["scores"].max()
             predictions = {
-                "model_conf": max_prob,
+                "model_conf": max_prob.item(),
                 "answer": self.processors["answer_processor"].idx2word(max_ind),
             }
             logger.info("predictions at the end of inference %s", predictions)


### PR DESCRIPTION
- Fixes VQA handler's prediction output for model confidence to return a python float number instead of tensor 