### PR TITLE
fixed known badge issues, including awarding badges too many times an…

### DIFF
--- a/api/controllers/models.py
+++ b/api/controllers/models.py
@@ -14,7 +14,6 @@ from common.config import config
 from common.logging import logger
 from models.badge import BadgeModel
 from models.model import DeploymentStatusEnum, ModelModel
-from models.notification import NotificationModel
 from models.round import RoundModel
 from models.score import ScoreModel
 from models.task import TaskModel
@@ -134,12 +133,6 @@ def do_upload(credentials):
             )
 
             user_dict = user.to_dict()
-
-            if user_dict["models_submitted"] == 0:
-                bm = BadgeModel()
-                nm = NotificationModel()
-                bm.addBadge({"uid": user_dict["id"], "name": "MODEL_BUILDER"})
-                nm.create(user_dict["id"], "NEW_BADGE_EARNED", "MODEL_BUILDER")
 
             um = UserModel()
             um.incrementModelSubmitCount(user_dict["id"])

--- a/api/migrations/20210211_01_yDiqU-delete-badges-awarded-too-many-times.py
+++ b/api/migrations/20210211_01_yDiqU-delete-badges-awarded-too-many-times.py
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+Delete badges that were awarded too many times by a buggy cronjob and won't be
+removed by the fixed cronjob.
+"""
+
+from yoyo import step
+
+
+__depends__ = {
+    "20210127_01_sHlix-add-round-user-example-info-table",
+    "20210205_01_6LJTC-entailing-to-entailed",
+}
+
+steps = [
+    step(
+        "DELETE FROM badges WHERE name='FIRST_VALIDATED_FOOLING' or name='FIRST_STEPS'"
+    )
+]

--- a/api/models/notification.py
+++ b/api/models/notification.py
@@ -21,7 +21,8 @@ class Notification(Base):
     type = db.Column(db.String(length=255))
     """
     NEW_BADGE_EARNED
-    ...
+    BADGE_REMOVED_STREAK
+    BADGE_REMOVED_MODEL
     """
 
     message = db.Column(db.Text)


### PR DESCRIPTION
…d miscounting for streaks.

* Examples were counted for streak purposes in the cronjob even if the model wasn't fooled or the example was retracted - this should now be fixed.
* If the user didn't log in to claim the badges awarded by the cronjob, the next cronjob would duplicate the badges. This shouldn't happen anymore.
* The added db migration (plus running the cronjob again) will fix the incorrect badges in the badge table.
* An old badge awarding artifact still lingered in models.py - this is now removed.
* I also added some missing comments to notifications.py