### PR TITLE
[fix] onboarding properly failing people

### DIFF
--- a/annotators/run_mturk.py
+++ b/annotators/run_mturk.py
@@ -94,13 +94,14 @@ def main(cfg: DictConfig) -> None:
 
     # mturk_specific_qualifications
 
-    # TODO: How to set onboarding ready?
-    def onboarding_always_valid(onboarding_data):
-        return True
+    def is_onboarding_successful(onboarding_data):
+        if "output" in onboarding_data and "success" in onboarding_data["output"]:
+            return onboarding_data["outputs"]["success"]
+        return False
 
     shared_state = SharedStaticTaskState(
         static_task_data=static_task_data,
-        validate_onboarding=onboarding_always_valid,
+        validate_onboarding=is_onboarding_successful,
         task_config=dict(cfg.dynabench),
     )
 


### PR DESCRIPTION
* When we launch tasks, for testing purposes, we should deliberately try to fail onboarding and see if you get banned.
* This PR makes it so that when people failed onboarding, they are getting banned to do the task.
  * the behavior previously was that if you failed onboarding, you are still allowed to do the main task. 