### PR TITLE
Added loading icon. Images keep aspect ratio.

### DIFF
--- a/frontends/web/mturk-src/components/vqa/src/CreateVQAMturkInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/CreateVQAMturkInterface.js
@@ -6,11 +6,11 @@
 
 import React from 'react';
 import AtomicImage from "../../../../src/containers/AtomicImage.js";
+import ErrorAlert from "../../../../src/containers/ErrorAlert.js"
 import CheckVQAModelAnswer from "../../../../src/containers/CheckVQAModelAnswer.js";
 import { VQAFeedbackCard } from "./VQAFeedbackCard.js";
 import { KeyboardShortcuts } from "../../../../src/containers/KeyboardShortcuts.js"
 import {
-    Alert,
     Container,
     Row,
     Card,
@@ -461,7 +461,7 @@ class CreateVQAMturkInterface extends React.Component {
                 </p>
             </>
         )
-        const contextContent = this.state.context && <AtomicImage src={this.state.context.context} maxHeight={600} maxWidth={900}/>
+        const contextContent = this.state.context.context && <AtomicImage src={this.state.context.context} maxHeight={500} maxWidth={800}/>
         const responseInfo = this.state.responseContent.map((response, idx) => {
             let classNames = "hypothesis rounded border";
             let feedbackContent = <></>;
@@ -585,10 +585,7 @@ class CreateVQAMturkInterface extends React.Component {
                         </span>
                     )}
                     {this.state.showErrorAlert && (
-                        <Alert variant={"danger"} className="px-2 mx-0" style={{ width: '100%'}}>
-                            There is a problem with the platform.
-                            Please contact <Alert.Link href="mailto:dynabench@fb.com">dynabench@fb.com</Alert.Link>.
-                        </Alert>
+                        <ErrorAlert/>
                     )}
                 </Row>
                 <KeyboardShortcuts

--- a/frontends/web/src/containers/AtomicImage.js
+++ b/frontends/web/src/containers/AtomicImage.js
@@ -6,30 +6,68 @@
 
 import React from "react";
 import Magnifier from "react-magnifier";
+import ErrorAlert from "./ErrorAlert.js";
 
 class AtomicImage extends React.Component {
+
+   constructor(props) {
+      super(props);
+      this.state = {
+         isImgLoaded: false,
+         width: 0,
+         height: this.props.maxHeight,
+      };
+   }
+
+   componentDidUpdate(prevProps) {
+      if (prevProps.src !== this.props.src) {
+         this.setState({ isImgLoaded: false });
+      }
+   }
+
+   onImgLoad = ({ target: img }) => {
+      const aspectRatio =  img.naturalWidth / img.naturalHeight;
+      const { maxHeight, maxWidth } = this.props;
+      let height = 0, width = 0;
+      if (maxHeight * aspectRatio > maxWidth) {
+         width = maxWidth;
+         height = maxWidth / aspectRatio;
+      } else {
+         height = maxHeight;
+         width = maxHeight * aspectRatio;
+      }
+      this.setState({
+         width,
+         height,
+         isImgLoaded: true,
+      })
+   }
+
    render() {
       if (this.props.src && this.props.src.length > 0) {
          return <>
-            <div style={{alignSelf: "center"}}>
-               <Magnifier
-                  mgWidth={250}
-                  mgHeight={250}
-                  width={"auto"}
-                  height={"auto"}
-                  src={this.props.src}
-                  mgShape={"square"}
-                  style={{
-                     display: "block"
-                  }}
-               />
+            <img src={this.props.src} style={{ display: "none" }} onLoad={this.onImgLoad}/>
+            <div className="d-flex align-items-center justify-content-center" style={{ height: this.state.height }}>
+               {this.state.isImgLoaded ? (
+                  <Magnifier
+                     mgWidth={250}
+                     mgHeight={250}
+                     width={this.state.width}
+                     height={this.state.height}
+                     src={this.props.src}
+                     mgShape={"square"}
+                     style={{
+                        display: this.state.isImgLoaded ? "block" : "none"
+                     }}
+                  />
+                  ) : (
+                  <div className="spinner-border" role="status"/>
+               )}
             </div>
          </>
       } else {
          return (
-            <div className="mb-1 p-3 light-gray-bg">
-               Loading...
-            </div>
+            <ErrorAlert/>
          )
       }
    }

--- a/frontends/web/src/containers/ErrorAlert.js
+++ b/frontends/web/src/containers/ErrorAlert.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { Alert } from "react-bootstrap";
+
+class ErrorAlert extends React.Component {
+    render() {
+        return (
+            <Alert variant={"danger"} className="px-2 mx-0" style={{ width: '100%'}}>
+                There is a problem with the platform.
+                Please contact <Alert.Link href="mailto:dynabench@fb.com">dynabench@fb.com</Alert.Link>.
+            </Alert>
+        )
+    }
+}
+
+export default ErrorAlert;


### PR DESCRIPTION
https://user-images.githubusercontent.com/23566456/108497423-070b8b00-7271-11eb-8ada-6bd426a91e07.mov


https://drive.google.com/file/d/1OoGpBgMQte0uUe4tVCpJF5Wo95oThYXS/view?usp=sharing


https://user-images.githubusercontent.com/23566456/108568125-1faa8e00-72cf-11eb-8e59-7b01ecc260ce.mov

The video above (the first one) is how it looks with out a loading icon. It is weird specially in sandbox where requests are slower. As you can see the counter of trials changes first. Then the question and at this point the previous image is still there. We should remove it and show something else while the image is loaded (IMO). This video shows how it is loaded with the loading icon.