### PR TITLE
Added pre-commit hooks for prettier, stylelint and eslint.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,28 @@ repos:
     hooks:
     - id: black
       language_version: python3.7
+
+-   repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.2.1
+    hooks:
+    -   id: prettier
+        files: \.[jt]sx?$
+
+-   repo: https://github.com/awebdeveloper/pre-commit-stylelint
+    rev: 0.0.2
+    hooks:
+    -   id: stylelint
+        args: [--fix]
+        additional_dependencies:
+            - stylelint@13.11.0
+            - stylelint-config-standard@20.0.0
+
+-   repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v7.21.0
+    hooks:
+    -   id: eslint
+        args: [--fix]
+        files: \.[jt]sx?$
+        types: [file]
+        additional_dependencies:
+            - eslint-config-react-app

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,16 @@
+{
+  "extends": ["stylelint-config-standard"],
+  "rules": {
+    "indentation": 4,
+    "font-family-no-missing-generic-family-keyword": [
+      true,
+      {
+        "ignoreFontFamilies": [
+          "OpenSansLight",
+          "OpenSansRegular",
+          "OpenSansSemiBold"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds prettier, stylelint and eslint pre-commit hooks in order to run the linters before committing a file. Stylelint and eslint, fix some of the errors automatically when they run, some errors have to be fixed manually. Prettier formats the code automatically. The hooks do the following:

-  Eslint checks for errors in .js and .jsx files, includes the configuration recommended by create-react-app.
- Prettier formats .js and .jsx files.
- Stylelint formats .css files. It uses stylelint-config-standard.


