### PR TITLE
Added buttons to change examples in onboarding in the main div. It al…

### DIFF
--- a/frontends/web/mturk-src/App.css
+++ b/frontends/web/mturk-src/App.css
@@ -56,3 +56,27 @@
   color: black;
   background-color: #dc3545!important;
 }
+
+.carousel-control-prev-icon {
+    width: 50px;
+    height: 50px;
+}
+
+.carousel-control-next-icon {
+    width: 50px;
+    height: 50px;
+}
+
+.carousel-control-next {
+  display: inline-block;
+  float: right;
+  margin-top: 320px;
+  filter: invert(100%);
+}
+
+.carousel-control-prev {
+  display: inline-block;
+  float: left;
+  margin-top: 320px;
+  filter: invert(100%);
+}

--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/ExampleCard.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/ExampleCard.js
@@ -1,0 +1,86 @@
+import React from "react";
+import {
+    Card,
+    Row,
+    Col
+} from 'react-bootstrap';
+import AtomicImage from "../../../../../src/containers/AtomicImage.js";
+
+class ExampleCard extends React.Component {
+    render() {
+        return (
+            <Card className="d-flex justify-content-center overflow-hidden" style={{ height: "auto" }}>
+                <Card.Header className="mb-4">
+                    {this.props.example.isValid ? (
+                        <h5 className="text-uppercase dark-blue-color spaced-header">
+                            {this.props.example.isValid ? "Valid Question" : "Invalid Question"}
+                        </h5>
+                    ) : (
+                        <p><b style={{ color: "red" }}>INVALID QUESTION {this.props.onboardingMode === "creation" ? " - DON'T ASK THIS TYPE OF QUESTION" :  ""}</b> </p>
+                    )}
+                </Card.Header>
+                <AtomicImage src={this.props.example['imageUrl']} maxHeight={400} maxWidth={600}/>
+                <Card.Body className="overflow-auto pt-2" style={{ height: "auto" }}>
+                    <Card
+                        className="hypothesis rounded border m-3 card"
+                        style={{ minHeight: 120 }}>
+                        <Card.Body className="p-3">
+                            <Row>
+                                <Col>
+                                    <h6 className="text-uppercase dark-blue-color spaced-header">
+                                        Question:
+                                    </h6>
+                                    <p>
+                                        <small>{this.props.example['question']}</small>
+                                    </p>
+                                    <h6 className="text-uppercase dark-blue-color spaced-header">
+                                        Why is this {this.props.example.isValid ? (
+                                            "a valid"
+                                            ) : (
+                                                "an invalid"
+                                            )} question?
+                                    </h6>
+                                    <p>
+                                        <small>{this.props.example['explanation']}</small>
+                                    </p>
+                                    {this.props.example.isValid && (
+                                        <>
+                                            <h6 className="text-uppercase dark-blue-color spaced-header">
+                                                {this.props.onboardingMode === "creation" ? "AI " : ""} Answer:
+                                            </h6>
+                                            <p>
+                                                <small>{this.props.example['modelAns']}</small>
+                                            </p>
+                                        </>
+                                    )}
+                                    {this.props.example.isValid && (
+                                        <>
+                                            <h6 className="text-uppercase dark-blue-color spaced-header">
+                                                Determine if {this.props.onboardingMode === "creation" ? "AI" : "the answer"} is correct or not:
+                                            </h6>
+                                            <p>
+                                                <small>{this.props.example['userFeedback'][0]}</small>
+                                            </p>
+                                            {this.props.example['userFeedback'][0] === "Incorrect" && this.props.onboardingMode === "creation" && (
+                                                <>
+                                                    <h6 className="text-uppercase dark-blue-color spaced-header">
+                                                        Provide the correct answer:
+                                                    </h6>
+                                                    <p>
+                                                        <small>{this.props.example['userFeedback'][1]}</small>
+                                                    </p>
+                                                </>
+                                            )}
+                                        </>
+                                    )}
+                                </Col>
+                            </Row>
+                        </Card.Body>
+                    </Card>
+                </Card.Body>
+            </Card>
+        )
+    }
+}
+
+export default ExampleCard;

--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAExampleCards.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAExampleCards.js
@@ -1,13 +1,11 @@
-import React from 'react';
+import React from "react";
 import {
-    Card,
-    Row,
     Button,
     InputGroup,
-    Col
-} from 'react-bootstrap';
-import WarningMessage from "../WarningMessage.js"
-import AtomicImage from "../../../../../src/containers/AtomicImage.js";
+    Carousel
+} from "react-bootstrap";
+import WarningMessage from "../WarningMessage.js";
+import ExampleCard from "./ExampleCard.js";
 import { InvalidQuestionCharacteristics } from "../QuestionsCharacteristics.js";
 import getVQAValidInvalidExamples from "./Examples/VQAValidInvalidExamples.js";
 
@@ -22,26 +20,15 @@ class VQAExampleCards extends React.Component {
         }
     }
 
-    getNextExample = () => {
-
-        if (this.state.currIdx < this.examples.length - 1) {
-            this.setState({
-                currIdx: this.state.currIdx + 1,
-            }, () => {
-                if (this.state.currIdx >= this.examples.length - 1) {
-                    this.props.setPhaseCompleted();
-                }
-            });
-        }
-    }
-
-    getPrevExample = () => {
-        if (this.state.currIdx > 0) {
-            this.setState(state => {
-                return { currIdx: state.currIdx - 1 };
-            });
-        }
-    }
+    handleSelect = (selectedIndex, e) => {
+        this.setState({
+            currIdx: selectedIndex
+        }, () => {
+            if (this.state.currIdx >= this.examples.length - 1) {
+                this.props.setPhaseCompleted();
+            }
+        })
+    };
 
     render() {
         let phaseInstructionsButton = <></>;
@@ -67,21 +54,11 @@ class VQAExampleCards extends React.Component {
                 </p>
             </div>
         :   <></>
-        const exampleSelector = <InputGroup className="mb-3">
-            <Button
-                className="btn btn-sm btn-success"
-                onClick={this.getPrevExample}
-                disabled={this.state.currIdx === 0}>
-                    Previous Example
-            </Button>
-            <Button
-                className="btn btn-sm btn-success"
-                style={{ marginLeft: 5 }}
-                onClick={this.getNextExample}
-                disabled={this.state.currIdx === this.examples.length - 1}>
-                    Next Example
-            </Button>
-        </InputGroup>
+        const exampleCards = this.examples.map(example =>
+            <Carousel.Item>
+                <ExampleCard example={example} onboardingMode={this.props.onboardingMode}/>
+            </Carousel.Item>
+        );
         const exampleTracker = <small style={{ padding: 7 }}>Example: {this.state.currIdx + 1} / {this.examples.length}</small>
         return (
             <>
@@ -89,77 +66,13 @@ class VQAExampleCards extends React.Component {
                 {phaseInstructionsButton}
                 {phaseInstructions}
                 <WarningMessage/>
-                {exampleSelector}
-                <Card className="d-flex justify-content-center overflow-hidden" style={{ height: "auto" }}>
-                    <Card.Header className="mb-4">
-                        {this.examples[this.state.currIdx].isValid ? (
-                            <h5 className="text-uppercase dark-blue-color spaced-header">
-                                {this.examples[this.state.currIdx].isValid ? "Valid Question" : "Invalid Question"}
-                            </h5>
-                        ) : (
-                            <p><b style={{ color: "red" }}>INVALID QUESTION {this.props.onboardingMode === "creation" ? " - DON'T ASK THIS TYPE OF QUESTION" :  ""}</b> </p>
-                        )}
-                    </Card.Header>
-                    <AtomicImage src={this.examples[this.state.currIdx]['imageUrl']} maxHeight={400} maxWidth={600}/>
-                    <Card.Body className="overflow-auto pt-2" style={{ height: "auto" }}>
-                        <Card
-                            className="hypothesis rounded border m-3 card"
-                            style={{ minHeight: 120 }}>
-                            <Card.Body className="p-3">
-                                <Row>
-                                    <Col>
-                                        <h6 className="text-uppercase dark-blue-color spaced-header">
-                                            Question:
-                                        </h6>
-                                        <p>
-                                            <small>{this.examples[this.state.currIdx]['question']}</small>
-                                        </p>
-                                        <h6 className="text-uppercase dark-blue-color spaced-header">
-                                            Why is this {this.examples[this.state.currIdx].isValid ? (
-                                                "a valid"
-                                                ) : (
-                                                    "an invalid"
-                                                )} question?
-                                        </h6>
-                                        <p>
-                                            <small>{this.examples[this.state.currIdx]['explanation']}</small>
-                                        </p>
-                                        {this.examples[this.state.currIdx].isValid && (
-                                            <>
-                                                <h6 className="text-uppercase dark-blue-color spaced-header">
-                                                    {this.props.onboardingMode === "creation" ? "AI " : ""} Answer:
-                                                </h6>
-                                                <p>
-                                                    <small>{this.examples[this.state.currIdx]['modelAns']}</small>
-                                                </p>
-                                            </>
-                                        )}
-                                        {this.examples[this.state.currIdx].isValid && (
-                                            <>
-                                                <h6 className="text-uppercase dark-blue-color spaced-header">
-                                                    Determine if {this.props.onboardingMode === "creation" ? "AI" : "the answer"} is correct or not:
-                                                </h6>
-                                                <p>
-                                                    <small>{this.examples[this.state.currIdx]['userFeedback'][0]}</small>
-                                                </p>
-                                                {this.examples[this.state.currIdx]['userFeedback'][0] === "Incorrect" && this.props.onboardingMode === "creation" && (
-                                                    <>
-                                                        <h6 className="text-uppercase dark-blue-color spaced-header">
-                                                            Provide the correct answer:
-                                                        </h6>
-                                                        <p>
-                                                            <small>{this.examples[this.state.currIdx]['userFeedback'][1]}</small>
-                                                        </p>
-                                                    </>
-                                                )}
-                                            </>
-                                        )}
-                                    </Col>
-                                </Row>
-                            </Card.Body>
-                        </Card>
-                    </Card.Body>
-                </Card>
+                <Carousel
+                    activeIndex={this.state.currIdx}
+                    interval={null}
+                    wrap={false}
+                    onSelect={this.handleSelect}>
+                    {exampleCards}
+                </Carousel>
                 {exampleTracker}
             </>
         )


### PR DESCRIPTION
Added buttons to change examples in onboarding in the main div. It also supports key shortcuts (arrows left and right) to change the example.

https://user-images.githubusercontent.com/23566456/108797776-a5d60700-7551-11eb-9505-e5f149866fd1.mov

- At the beginning there is no option to go to the previous example (since the first one is being shown).
- At the end, the button to go to the next example is not shown.
- When the last example is shown, the button to go to the next phase is shown.

https://user-images.githubusercontent.com/23566456/108798176-cce10880-7552-11eb-9d91-ba7a3b846f0d.mov

- Added the video above to show how it looks when going to a previous example.