### PR TITLE
Removed unnecessary params passed to the model.

### DIFF
--- a/frontends/web/src/containers/CreateInterface.js
+++ b/frontends/web/src/containers/CreateInterface.js
@@ -855,12 +855,15 @@ class CreateInterface extends React.Component {
           this.setState({ target: answer_text });
         }
       }
-
+      let contextKey = "context";
+      let hypothesisKey = "hypothesis";
+      if (this.state.task.type === "VQA") {
+        contextKey = "image_url";
+        hypothesisKey = "question";
+      }
       let modelInputs = {
-        image_url: this.state.context.context,
-        question: this.state.hypothesis,
-        context: this.state.context.context,
-        hypothesis: this.state.hypothesis,
+        [contextKey]: this.state.context.context,
+        [hypothesisKey]: this.state.hypothesis,
         answer: answer_text,
         insight: false,
       };


### PR DESCRIPTION
Issue: Unnecessary fields were removed in the object that is sent as parameter to get the model response. These unnecessary fields were `image_url` and `question` which are used only in vqa. These fields were included for all the tasks.

![image](https://user-images.githubusercontent.com/23566456/109234282-0010db00-7791-11eb-94c6-1120fc1d5e99.png)

Modification: Before calling the `getModelResponse` method it checks the current task. If the task is vqa the object sent as parameter includes the keys `image_url` and `question`. Otherwise, these fields are named `context` and `hypothesis`.

![image](https://user-images.githubusercontent.com/23566456/109234794-fb98f200-7791-11eb-8a4e-8460c5344d29.png)
Called in NLI

![image](https://user-images.githubusercontent.com/23566456/109234941-4d417c80-7792-11eb-832a-1fb0741b8cec.png)
Called in VQA
