### PR TITLE
[2/N] fix 4 bugs: remove state variables; id base; check edge cases

### DIFF
--- a/frontends/web/src/containers/CheckVQAModelAnswer.js
+++ b/frontends/web/src/containers/CheckVQAModelAnswer.js
@@ -15,7 +15,7 @@ class CheckVQAModelAnswer extends React.Component {
         this.state = {
             correctAnswer: "",
             disableCorrectButton: false,
-            disableSubmitButton: false
+            disableSubmitButton: false,
         };
     }
 
@@ -29,13 +29,13 @@ class CheckVQAModelAnswer extends React.Component {
         const formattedAnswer = this.state.correctAnswer.trim();
         if (formattedAnswer.length > 0) {
             this.setState({ disableSubmitButton: true })
-            this.props.updateExample(formattedAnswer, "yes");
+            this.props.updateExample(this.props.eid, formattedAnswer, "yes");
         }
     }
 
     handleCorrectButtonClick = () => {
         this.setState({ disableCorrectButton: true })
-        this.props.updateExample(this.props.modelPredStr, "no");
+        this.props.updateExample(this.props.eid, this.props.modelPredStr, "no");
     }
 
     handleIncorrectButtonClick = () => {
@@ -45,7 +45,7 @@ class CheckVQAModelAnswer extends React.Component {
     render() {
         if (this.props.fooled === "no") {
             return null;
-        } else if (this.props.loadingResponse) {
+        } else if (this.props.loadingResponse || this.props.eid === "unknown") {
             return (
                 <div className="d-flex align-items-center justify-content-center" style={{ width: "100%", height: 120 }}>
                     <div className="spinner-border" role="status"/>
@@ -99,10 +99,18 @@ class CheckVQAModelAnswer extends React.Component {
                 <KeyboardShortcuts
                     mapKeyToCallback={{
                         "w": {
-                            callback: () => this.handleCorrectButtonClick(),
+                            callback: () => {
+                                if (this.props.eid !== "unknown") {
+                                    this.handleCorrectButtonClick()
+                                }
+                            }
                         },
                         "s": {
-                            callback: () => this.handleIncorrectButtonClick(),
+                            callback: () => {
+                                if (this.props.eid !== "unknown") {
+                                    this.handleIncorrectButtonClick()
+                                }
+                            }
                         },
                     }}
                 />


### PR DESCRIPTION
1. Make number of tries counter a set so that if called multiple times, it does not affect state. This is to fix the `counter` problem the original PR of #309 was trying to fix. This is the correct way to fix this particular issue.
2. Fixing a race condition where the example ID could be undefined. This time we pass the example ID from checkVQAAnswer component so it cannot be undefined. We also added edge condition check to make sure if it is unknown, then we do nothing.
3. Fixing a race condition where StoreExample is called with an empty question (this happens when you switch context really quickly before StoreExample is called, and therefore the state variable this.question is empty causing a signature mismatch problem)
4. Remove the state: fooled, and instead opt to use the last responseContent's fooled property. The state variable fooled and the last responseContent's fooled property could get inconsistent. We should try to use just one variable to represent state, rather than multiple.