### PR TITLE
VQA Validation: Changed shortcuts from arrows to WASD. Toggle instructions.

### DIFF
--- a/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
@@ -139,15 +139,14 @@ class VQAValidationInterface extends React.Component {
                 </p>
                 <p>You can also use the key shortcuts to operate:</p>
                 <ul className="mx-3" style={{ listStyleType: "disc" }}>
-                    <li><b>Arrow Up:</b> Valid Question.</li>
-                    <li><b>Arrow Down:</b> Invalid Question.</li>
+                    <li><b>w:</b> Valid Question.</li>
+                    <li><b>s:</b> Invalid Question.</li>
                     <li><b>f:</b> Flag Question.</li>
-                    <li><b>Arrow Right:</b> Correct Answer.</li>
-                    <li><b>Arrow Left:</b> Incorrect Answer.</li>
-                    <li><b>s:</b> Show Instructions.</li>
-                    <li><b>h:</b> Hide Instructions.</li>
+                    <li><b>a:</b> Incorrect Answer.</li>
+                    <li><b>d:</b> Correct Answer.</li>
+                    <li><b>j:</b> Toggle Show/Hide Instructions.</li>
                     <li><b>Escape:</b> Clear Selections.</li>
-                    <li> <b>Enter:</b> Submit Validation.</li>
+                    <li><b>Enter:</b> Submit Validation.</li>
                 </ul>
             </>
         ): (
@@ -261,11 +260,11 @@ class VQAValidationInterface extends React.Component {
                 <KeyboardShortcuts
                     allowedShortcutsInText={["enter", "escape"]}
                     mapKeyToCallback={{
-                        "arrowup": {
+                        "w": {
                             callback: (valState) => this.setQuestionValidationState(valState),
                             params: this.VALIDATION_STATES.CORRECT
                         },
-                        "arrowdown": {
+                        "s": {
                             callback: (valState) => this.setQuestionValidationState(valState),
                             params: this.VALIDATION_STATES.INCORRECT
                         },
@@ -277,19 +276,16 @@ class VQAValidationInterface extends React.Component {
                             callback: (valState) => this.setQuestionValidationState(valState),
                             params: this.VALIDATION_STATES.UNKNOWN
                         },
-                        "arrowright": {
+                        "d": {
                             callback: (valState) => this.setResponseValidationState(valState),
                             params: this.VALIDATION_STATES.CORRECT
                         },
-                        "arrowleft": {
+                        "a": {
                             callback: (valState) => this.setResponseValidationState(valState),
                             params: this.VALIDATION_STATES.INCORRECT
                         },
-                        "s": {
-                            callback: () => this.setState({ showInstructions: true })
-                        },
-                        "h": {
-                            callback: () => this.setState({ showInstructions: false })
+                        "j": {
+                            callback: () => this.setState((state, props) => {return { showInstructions: !state.showInstructions }})
                         },
                         "enter": {
                             callback: () => this.submitValidation()


### PR DESCRIPTION
Modified the keys issued as shortcuts, instead of arrows we are using WASD. Modified instructions shortcut to be simply a toggle activated with key "j". Changed shortcuts in the following way:

<img width="267" alt="Screen Shot 2021-02-26 at 21 12 58" src="https://user-images.githubusercontent.com/23566456/109373949-843d8e00-7877-11eb-9273-1e176e5a8667.png">

The error mentioned: Cannot validate own example is a DB issue. The example metadata did not included an annotator id. If the example to be validated does not include this field, this error is returned.

`if (
            "annotator_id" not in example_metadata
            or example_metadata["annotator_id"] == data["uid"]
        ) and mode != "owner":
            bottle.abort(403, "Access denied (cannot validate your own example)")`

<img width="777" alt="Screen Shot 2021-02-26 at 20 47 06" src="https://user-images.githubusercontent.com/23566456/109374020-075ee400-7878-11eb-8729-614bf853175c.png">
