### PR TITLE
Feat/task specific onboarding instructions automatically appear

### DIFF
--- a/frontends/web/src/containers/CreateInterface.js
+++ b/frontends/web/src/containers/CreateInterface.js
@@ -1151,7 +1151,7 @@ class CreateInterface extends React.Component {
             <ButtonGroup>
               <Annotation placement="left" tooltip="Click to show help overlay">
                 <button type="button" className="btn btn-outline-primary btn-sm btn-help-info"
-                  onClick={() => { this.setState({dontShowAnnotations: !this.state.dontShowAnnotations})}}
+                  onClick={() => { this.setState((prevState) => ({dontShowAnnotations: !prevState.dontShowAnnotations}))}}
                 ><i className="fas fa-question"></i></button>
               </Annotation>
               <Annotation placement="bottom" tooltip="Click to learn more details about this task challenge">

--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -629,7 +629,7 @@ class TaskPage extends React.Component {
             <ButtonGroup>
               <Annotation placement="left" tooltip="Click to show help overlay">
                 <button type="button" className="btn btn-outline-primary btn-sm btn-help-info"
-                  onClick={() => { this.setState({taskVisited: !this.state.taskVisited})}}
+                  onClick={() => { this.setState((prevState) => ({taskVisited: !prevState.taskVisited}))}}
                 ><i className="fas fa-question"></i></button>
               </Annotation>
               {this.context.api.isTaskOwner(this.context.user, this.state.task.id) || this.context.user.admin


### PR DESCRIPTION
For #197. The behavior is as follows:

The first time a user goes to a particular task page, the help overlay automatically appears. The first time a user goes to a particular create interface, the help overlay automatically appears. When the user clicks out of the help overlay in the create interface for the first time, the task specific instructions automatically appear.