### PR TITLE
Modified VQA-VAL desc. Updated VQA type, has_context and has_answer.

### DIFF
--- a/api/migrations/20210303_01_fAMkR-set-type-has-context-and-has-answer-fields-in-vqa-main-task.py
+++ b/api/migrations/20210303_01_fAMkR-set-type-has-context-and-has-answer-fields-in-vqa-main-task.py
@@ -1,0 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+Set type, has_context and has_answer fields in VQA main task.
+"""
+
+from yoyo import step
+
+
+__depends__ = {"20210224_02_yTRsk-add-aws-metrics-to-scores-table"}
+
+steps = [
+    step(
+        "UPDATE `tasks` SET type='VQA', has_context=1, has_answer=1 "
+        + "WHERE shortname='VQA'"
+    )
+]

--- a/api/migrations/20210303_02_vVPzx-modify-description-message-for-vqa-val.py
+++ b/api/migrations/20210303_02_vVPzx-modify-description-message-for-vqa-val.py
@@ -1,0 +1,20 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+Modify description message for VQA-VAL.
+"""
+
+from yoyo import step
+
+
+__depends__ = {
+    "20210303_01_fAMkR-set-type-has-context-and-has-answer-fields-in-vqa-main-task"
+}
+
+steps = [
+    step(
+        "UPDATE `tasks` SET `desc`='Visual Question "
+        + "Answering Validation involves checking that "
+        + "questions are good and fooling the model.' WHERE shortname='VQA-VAL'"
+    )
+]


### PR DESCRIPTION
In this PR two rows of the `tasks` table were modified.

- VQA-VAL: Updated description message. `desc='Visual Question Answering Validation involves checking that questions are good and fooling the model.'`.

- VQA (main task): Set `type=VQA`, `has_context=1`, `has_answer=1`. 

![image](https://user-images.githubusercontent.com/23566456/109858934-0801cc80-7c22-11eb-8fbb-49e11cbad0d3.png)

No rollback statement specified.
