### PR TITLE
Solved errors marked by eslint and stylelint manually.

### DIFF
--- a/frontends/web/mturk-src/components/divyansh/qa-1-verify/VerifyInterface.js
+++ b/frontends/web/mturk-src/components/divyansh/qa-1-verify/VerifyInterface.js
@@ -78,12 +78,14 @@ class VerifyInterface extends React.Component {
           action_label,
           this.props.providerWorkerId
         )
-        .then((result) => {
-          this.props.onSubmit(this.state.content);
-        }),
-        (error) => {
-          console.log(error);
-        };
+        .then(
+          (result) => {
+            this.props.onSubmit(this.state.content);
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
     }
   }
   render() {

--- a/frontends/web/mturk-src/components/divyansh/qa-1-verify/VerifyInterfaceQA.js
+++ b/frontends/web/mturk-src/components/divyansh/qa-1-verify/VerifyInterfaceQA.js
@@ -110,12 +110,14 @@ class VerifyInterface extends React.Component {
       var metadata = { annotator_id: this.props.providerWorkerId };
       this.api
         .validateExample(this.state.example.id, action, "user", metadata)
-        .then((result) => {
-          this.props.onSubmit(this.state);
-        }),
-        (error) => {
-          console.log(error);
-        };
+        .then(
+          (result) => {
+            this.props.onSubmit(this.state);
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
     }
   }
   render() {

--- a/frontends/web/mturk-src/components/divyansh/qa-1/core.jsx
+++ b/frontends/web/mturk-src/components/divyansh/qa-1/core.jsx
@@ -170,12 +170,6 @@ class DivyanshQATaskOnboarder extends React.Component {
               />{" "}
             </Row>
           )}
-          {this.state.onboardingStep == 10 && (
-            <Row>
-              {" "}
-              <CreateInterfaceOnboardingStep10 />{" "}
-            </Row>
-          )}
           {this.state.showOnboardingSubmit && (
             <Row>
               {" "}

--- a/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
@@ -161,45 +161,49 @@ class VQAValidationInterface extends React.Component {
           metadata,
           this.props.providerWorkerId
         )
-        .then((result) => {
-          this.setState(
-            (prevState, _) => {
-              const newTotalValidationsSoFar = new Set(
-                prevState.totalValidationsSoFar
-              );
-              if (prevState.example.id) {
-                newTotalValidationsSoFar.add(prevState.example.id);
-              }
+        .then(
+          (result) => {
+            this.setState(
+              (prevState, _) => {
+                const newTotalValidationsSoFar = new Set(
+                  prevState.totalValidationsSoFar
+                );
+                if (prevState.example.id) {
+                  newTotalValidationsSoFar.add(prevState.example.id);
+                }
 
-              let newHistory = [
-                ...prevState.history,
-                {
-                  id: prevState.example.id,
-                  questionValidationState: prevState.questionValidationState,
-                  responseValidationState: prevState.responseValidationState,
-                  flagReason: prevState.flagReason,
-                  totalNumValidationsSoFar: newTotalValidationsSoFar.size,
-                },
-              ];
+                let newHistory = [
+                  ...prevState.history,
+                  {
+                    id: prevState.example.id,
+                    questionValidationState: prevState.questionValidationState,
+                    responseValidationState: prevState.responseValidationState,
+                    flagReason: prevState.flagReason,
+                    totalNumValidationsSoFar: newTotalValidationsSoFar.size,
+                  },
+                ];
 
-              return {
-                totalValidationsSoFar: newTotalValidationsSoFar,
-                history: newHistory,
-              };
-            },
-            () => {
-              if (this.state.totalValidationsSoFar.size === this.batchAmount) {
-                this.props.onSubmit(this.state.history);
-              } else {
-                this.getNewExample();
+                return {
+                  totalValidationsSoFar: newTotalValidationsSoFar,
+                  history: newHistory,
+                };
+              },
+              () => {
+                if (
+                  this.state.totalValidationsSoFar.size === this.batchAmount
+                ) {
+                  this.props.onSubmit(this.state.history);
+                } else {
+                  this.getNewExample();
+                }
               }
-            }
-          );
-        }),
-        (error) => {
-          console.log(error);
-          this.setState({ showErrorAlert: true });
-        };
+            );
+          },
+          (error) => {
+            console.log(error);
+            this.setState({ showErrorAlert: true });
+          }
+        );
     });
   };
 

--- a/frontends/web/src/components/Avatar/Avatar.css
+++ b/frontends/web/src/components/Avatar/Avatar.css
@@ -41,7 +41,6 @@
     width: 100%;
     height: 100%;
     border-radius: 50%;
-    border-radius: 50%;
     -webkit-webkit: border radius 50%;
     -moz-webkit: border radius 50%;
     -ms-webkit: border radius 50%;

--- a/frontends/web/src/containers/App.css
+++ b/frontends/web/src/containers/App.css
@@ -173,12 +173,12 @@ table.inspectModel {
     margin-top: 20px;
 }
 
-table.inspectModel thead td {
-    background: #efefef;
-}
-
 table.inspectModel td {
     padding: 5px;
+}
+
+table.inspectModel thead td {
+    background: #efefef;
 }
 
 .spaced-header {
@@ -236,7 +236,18 @@ table.inspectModel td {
 }
 
 @keyframes pop {
-    0% { transform: scale(0); opacity: 0; }
-    50% { transform: scale(1.2); opacity: 1; }
-    100% { transform: scale(1); opacity: 1; }
+    0% {
+        transform: scale(0);
+        opacity: 0;
+    }
+
+    50% {
+        transform: scale(1.2);
+        opacity: 1;
+    }
+
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
 }

--- a/frontends/web/src/containers/HomePage.css
+++ b/frontends/web/src/containers/HomePage.css
@@ -27,6 +27,10 @@
     min-height: 120px;
 }
 
+.profile-card td {
+    padding: 24px;
+}
+
 .task-card .table td:last-child {
     font-weight: 700;
     text-align: right;
@@ -70,10 +74,6 @@
 
 .profile-card table {
     font-size: 14px;
-}
-
-.profile-card td {
-    padding: 24px;
 }
 
 .profile-card tr + tr {


### PR DESCRIPTION
This PR solves the remaining errors marked by eslint and stylelint that could not been auto fixed. These errrors are:

**Stylelint**
- Duplicated properties.
- Limit the number of declarations within a single-line declaration block.
- Disallow selectors of lower specificity from coming after overriding selectors of higher specificity.

**Eslint**
- The method `validateExample` had an error, the callback executed on failure was out of the `.then` method.
- `CreateInterfaceOnboardingStep10` this module was not defined in the project.

![image](https://user-images.githubusercontent.com/23566456/109888996-2085dd00-7c4a-11eb-8a6e-913666fa5046.png)
