### PR TITLE
Added eid as parameter when updating example in web interface and solved flag/retract bug.

### DIFF
--- a/frontends/web/src/containers/CheckVQAModelAnswer.js
+++ b/frontends/web/src/containers/CheckVQAModelAnswer.js
@@ -52,6 +52,7 @@ class CheckVQAModelAnswer extends React.Component {
                 </div>
             )
         }
+        const isValidExampleId = this.props.eid && this.props.eid !== "unknown";
         return (
             <div className="mt-3">
                 <span>The model predicted: <strong>{this.props.modelPredStr}</strong></span><br/>
@@ -100,14 +101,14 @@ class CheckVQAModelAnswer extends React.Component {
                     mapKeyToCallback={{
                         "w": {
                             callback: () => {
-                                if (this.props.eid !== "unknown") {
+                                if (isValidExampleId) {
                                     this.handleCorrectButtonClick()
                                 }
                             }
                         },
                         "s": {
                             callback: () => {
-                                if (this.props.eid !== "unknown") {
+                                if (isValidExampleId) {
                                     this.handleIncorrectButtonClick()
                                 }
                             }


### PR DESCRIPTION
This PR makes two things:

Adjusts an inconsistency between mturk and web platforms. In mturk, to avoid race conditions, the example id is passed to the component that allows the user to check the model’s answer (“Correct” and “Incorrect” buttons). The method to update the example with the correct answer should receive the id of the example to be updated.
Tests:
1. Spammed typing "w" while response is loading.
2. Spammed typing "s" while response is loading.
3. Spammed alternating 1 and 2. 

Solves an error in the UI that causes that the submission results are not hidden when the user retracts or flags the example. 
To repro the error, once the example is created click on either flag or retract.

Before:
The example was created, then the user clicked retract or flag and the submissions results still appeared in the card.
<img width="524" alt="Screen Shot 2021-03-04 at 3 32 26" src="https://user-images.githubusercontent.com/23566456/109943007-5783df00-7c9a-11eb-8bf4-5d9cf0e7a526.png">


After:
The example was created, then the user clicks retract or flag and the submissions results are replaced indicating that the example has been retracted or flagged.
<img width="626" alt="Screen Shot 2021-03-04 at 3 32 13" src="https://user-images.githubusercontent.com/23566456/109942980-50f56780-7c9a-11eb-94ef-92c0be0f0c3f.png">

