### PR TITLE
Added vqa to the web validation interface.

### DIFF
--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAQuizCard.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAQuizCard.js
@@ -53,7 +53,6 @@ class VQAQuizCard extends React.Component {
                       this.props.modelState === this.MODEL_STATES.INCORRECT
                     }
                     userMode="user"
-                    interfaceMode="mturk"
                     isQuestion={!this.props.isAnswer}
                     disabled={this.props.disableRadios}
                     header={
@@ -62,6 +61,7 @@ class VQAQuizCard extends React.Component {
                         : "Is the question above valid? (refer to the instructions to see the concept of valid and invalid questions)."
                     }
                     isFlaggingAllowed={false}
+                    isExplainingAllowed={false}
                     setCorrectSelected={() => {
                       this.props.setModelState(
                         this.props.index,

--- a/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
@@ -353,7 +353,8 @@ class VQAValidationInterface extends React.Component {
                               this.state.questionValidationState === FLAGGED
                             }
                             userMode={this.userMode}
-                            interfaceMode={this.interfaceMode}
+                            task={this.state.task}
+                            isExplainingAllowed={false}
                             isQuestion={true}
                             isFlaggingAllowed={true}
                             setCorrectSelected={() =>
@@ -396,7 +397,8 @@ class VQAValidationInterface extends React.Component {
                                 }
                                 flaggedSelected={false}
                                 userMode={this.userMode}
-                                interfaceMode={this.interfaceMode}
+                                task={this.state.task}
+                                isExplainingAllowed={false}
                                 isQuestion={false}
                                 isFlaggingAllowed={false}
                                 setCorrectSelected={() =>

--- a/frontends/web/src/containers/ExampleValidationActions.js
+++ b/frontends/web/src/containers/ExampleValidationActions.js
@@ -35,7 +35,7 @@ class ExampleValidationActions extends React.Component {
     const positiveTerm = this.props.isQuestion ? "Valid" : "Correct";
     const negativeTerm = this.props.isQuestion ? "Invalid" : "Incorrect";
     return (
-      <>
+      <div className="my-3">
         <h6 className="text-uppercase dark-blue-color spaced-header">
           {this.props.header || "Actions"}
         </h6>
@@ -69,56 +69,64 @@ class ExampleValidationActions extends React.Component {
           <i className="fas fa-thumbs-down"></i> &nbsp;{" "}
           {this.props.userMode === "owner" ? "Verified " : ""} {negativeTerm}
         </div>
-        <InputGroup className="ml-3">
-          {this.props.interfaceMode === "web" &&
-            this.props.incorrectSelected &&
-            {
-              NLI: (
-                <DropdownButton
-                  className="p-1"
-                  title={"Your corrected label: " + this.props.validatorLabel}
-                >
-                  {["entailed", "neutral", "contradictory"]
-                    .filter((target, _) => target !== this.props.example.target)
-                    .map((target, index) => (
-                      <Dropdown.Item
-                        onClick={() => this.props.setValidatorLabel(target)}
-                        key={index}
-                        index={index}
-                      >
-                        {target}
-                      </Dropdown.Item>
-                    ))}
-                </DropdownButton>
-              ),
-              QA:
-                "Please select the correct answer in the context. If it is not in the context, then flag this example.",
-              "Hate Speech": (
-                <div>
-                  You have proposed that the correct answer is{" "}
-                  <b>
-                    {
-                      ["hateful", "not-hateful"].filter(
-                        (target, _) => target !== this.props.example.target
-                      )[0]
-                    }
-                  </b>
-                </div>
-              ),
-              Sentiment: (
-                <div>
-                  You have proposed that the correct answer is{" "}
-                  <b>
-                    {
-                      ["positive", "negative"].filter(
-                        (target, _) => target !== this.props.example.target
-                      )[0]
-                    }
-                  </b>
-                </div>
-              ),
-            }[this.props.task.shortname]}
-        </InputGroup>
+        {this.props.isExplainingAllowed &&
+          this.props.task &&
+          this.props.incorrectSelected && (
+            <InputGroup className="ml-3">
+              {
+                {
+                  NLI: (
+                    <DropdownButton
+                      className="p-1"
+                      title={
+                        "Your corrected label: " + this.props.validatorLabel
+                      }
+                    >
+                      {["entailed", "neutral", "contradictory"]
+                        .filter(
+                          (target, _) => target !== this.props.example.target
+                        )
+                        .map((target, index) => (
+                          <Dropdown.Item
+                            onClick={() => this.props.setValidatorLabel(target)}
+                            key={index}
+                            index={index}
+                          >
+                            {target}
+                          </Dropdown.Item>
+                        ))}
+                    </DropdownButton>
+                  ),
+                  QA:
+                    "Please select the correct answer in the context. If it is not in the context, then flag this example.",
+                  "Hate Speech": (
+                    <div>
+                      You have proposed that the correct answer is{" "}
+                      <b>
+                        {
+                          ["hateful", "not-hateful"].filter(
+                            (target, _) => target !== this.props.example.target
+                          )[0]
+                        }
+                      </b>
+                    </div>
+                  ),
+                  Sentiment: (
+                    <div>
+                      You have proposed that the correct answer is{" "}
+                      <b>
+                        {
+                          ["positive", "negative"].filter(
+                            (target, _) => target !== this.props.example.target
+                          )[0]
+                        }
+                      </b>
+                    </div>
+                  ),
+                }[this.props.task.shortname]
+              }
+            </InputGroup>
+          )}
         {this.props.userMode === "user" && this.props.isFlaggingAllowed && (
           <div
             className="d-flex flex-row"
@@ -146,61 +154,63 @@ class ExampleValidationActions extends React.Component {
             </Col>
           </InputGroup>
         )}
-        {this.props.interfaceMode === "web" &&
-          (this.props.incorrectSelected ||
-            this.props.correctSelected ||
-            this.props.flaggedSelected) && (
-            <div>
-              <h6 className="text-uppercase dark-blue-color spaced-header">
-                Optionally, provide an explanation for this example:
-              </h6>
+        {(this.props.incorrectSelected ||
+          this.props.correctSelected ||
+          this.props.flaggedSelected) && (
+          <div>
+            {this.props.isExplainingAllowed && (
               <div className="mt-3">
-                {(this.props.incorrectSelected ||
-                  this.props.correctSelected) && (
+                <h6 className="text-uppercase dark-blue-color spaced-header">
+                  Optionally, provide an explanation for this example:
+                </h6>
+                <div className="mt-3">
+                  {(this.props.incorrectSelected ||
+                    this.props.correctSelected) &&
+                    this.props.task && (
+                      <div>
+                        <Form.Control
+                          type="text"
+                          placeholder={
+                            "Explain why " +
+                            (this.props.task.shortname === "QA"
+                              ? this.props.correctSelected
+                                ? "the given answer"
+                                : "your proposed answer"
+                              : this.props.correctSelected
+                              ? "the given label"
+                              : "your proposed label") +
+                            " is correct"
+                          }
+                          onChange={(e) =>
+                            this.props.setLabelExplanation(e.target.value)
+                          }
+                        />
+                      </div>
+                    )}
                   <div>
                     <Form.Control
                       type="text"
-                      placeholder={
-                        "Explain why " +
-                        (this.props.task.shortname === "QA"
-                          ? this.props.correctSelected
-                            ? "the given answer"
-                            : "your proposed answer"
-                          : this.props.correctSelected
-                          ? "the given label"
-                          : "your proposed label") +
-                        " is correct"
-                      }
+                      placeholder="Explain what you think the creator did to try to trick the model"
                       onChange={(e) =>
-                        this.props.setLabelExplanation(e.target.value)
+                        this.props.setCreatorAttemptExplanation(e.target.value)
                       }
                     />
                   </div>
-                )}
-                <div>
-                  <Form.Control
-                    type="text"
-                    placeholder="Explain what you think the creator did to try to trick the model"
-                    onChange={(e) =>
-                      this.props.setCreatorAttemptExplanation(e.target.value)
-                    }
-                  />
                 </div>
-                {this.props.task.shortname === "Hate Speech" && (
-                  <HateSpeechDropdown
-                    hateType={this.props.validatorHateType}
-                    dataIndex={this.props.index}
-                    onClick={(e) =>
-                      this.props.setValidatorHateType(
-                        e.target.getAttribute("data")
-                      )
-                    }
-                  />
-                )}
               </div>
-            </div>
-          )}
-      </>
+            )}
+            {this.props.task && this.props.task.shortname === "Hate Speech" && (
+              <HateSpeechDropdown
+                hateType={this.props.validatorHateType}
+                dataIndex={this.props.index}
+                onClick={(e) =>
+                  this.props.setValidatorHateType(e.target.getAttribute("data"))
+                }
+              />
+            )}
+          </div>
+        )}
+      </div>
     );
   }
 }


### PR DESCRIPTION
This PR adds the VQA task to the web validation interface. Currently validating VQA examples was not supported in the web platform, only in mturk.

![image](https://user-images.githubusercontent.com/23566456/110903883-bd411e00-82cd-11eb-8008-aca82b9ebd0c.png)
Both the question and the model's answer are validated. 

The `ExampleValidationActions` component displays three radio buttons to set the example as correct, incorrect or flagged. It can also be configured to ask for the correct answer/label and for user explanations.
![image](https://user-images.githubusercontent.com/23566456/110905956-e6af7900-82d0-11eb-8814-ecd2b2b294ed.png)

To flag an example a flag reason must be specified in order to create the validation.

For VQA the annotator validates the model's answers. For the other tasks the annotator's answer is validated.

Test Plan:
https://docs.google.com/document/d/1lRFcnASueaYBx_DBNVNFSX-U1qFCY2JkYiTo5ICBA5k/edit?usp=sharing