### PR TITLE
[fix] validation onboarding/instructions update

### DIFF
--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/Examples/VQAQuizExamples.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/Examples/VQAQuizExamples.js
@@ -1,4 +1,4 @@
-const VQAQuizExamples = {
+const creation_examples = {
     1:  [
             {
                 question: "Which woman looks older?",
@@ -108,6 +108,125 @@ const VQAQuizExamples = {
                 hint: "HINT: This question is not ambiguous but it is likely that not a lot of people know the answer. Try to avoid very specific questions that require some specialized knowledge on the topic. Relying on external knowledge is fine, but remember: another person should be able to answer the question."
             },
         ]
+}
+
+const validation_examples = {
+    1: [
+        {
+            question: "Which woman looks older?",
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000171966.jpg",
+            modelAns: "right",
+            isModelCorrect: true,
+            hint: "HINT: Look at their hair and facial features. Another person is likely going to agree.",
+            isAnswer: true
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000480890.jpg",
+            question: "Where is the man staring?",
+            modelAns: "at camera",
+            isModelCorrect: true,
+            hint: "HINT: You can assume that the man is aware that he is being photographed.",
+            isAnswer: true
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000462512.jpg",
+            question: "Which way is the convertible turning?",
+            modelAns: "left",
+            isModelCorrect: true,
+            hint: "HINT: The convertible is the black car.",
+            isAnswer: true
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000037409.jpg",
+            question: "Is Harley-Davidson the name of a motorcycle brand?",
+            isModelCorrect: false,
+            hint: "HINT: Although this can be inferred from the image there is no need to look at it to know this is true.",
+            isAnswer: false
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000507795.jpg",
+            question: "What direction are the stripes of the person with pink sleeves?",
+            isModelCorrect: true,
+            hint: "HINT: Although this can be inferred from the image. You have to find the stripes first. It may take some work, you should use the magnifier on every image.",
+            isAnswer: false
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000322341.jpg",
+            question: "Does the man at the train station have a hat on?",
+            isModelCorrect: true,
+            isAnswer: false,
+            hint: `HINT: This is not super obvious. You'd need to use the magnifier to see that there is actually a man at the train station and he indeed looks like he has a hat on. Remember try to spend some time on each image to give them the benefit of the doubt.`
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/val2014/COCO_val2014_000000565797.jpg",
+            question: "What is the brand of this car?",
+            isModelCorrect: false,
+            hint: "HINT: It is not possible to answer the question given that the image does not show enough information.",
+            isAnswer: false
+        }
+    ],
+    2: [
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000305598.jpg",
+            question: "Is the man wearing glasses who is watching the little girl?",
+            modelAns: "no",
+            isModelCorrect: false,
+            hint: "HINT: Please use magnifier by hovering the mouse over the image!",
+            isAnswer: true
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000163776.jpg",
+            question: "What style are the shoes of the woman on the left?",
+            modelAns: "sandals",
+            isModelCorrect: true,
+            hint: "HINT: The woman in black is on the left, she is wearing high heels sandals.",
+            isAnswer: true
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/val2014/COCO_val2014_000000274835.jpg",
+            question: "What is the name of the potatoes in the picture?",
+            modelAns: "potatoes",
+            isModelCorrect: false,
+            hint: "HINT: It looks like those potatos is called mashed potatos. Most people are likely going to say 'mashed potatoes' as the answer.",
+            isAnswer: true
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/val2014/COCO_val2014_000000328757.jpg",
+            question: "Are vegetables a healthy food?",
+            isModelCorrect: false,
+            isAnswer: false,
+            hint: "HINT: The answer to this question is not affected by the situation in the image.",
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000484597.jpg",
+            question: "What is the second word above Crawfords?",
+            isModelCorrect: true,
+            isAnswer: false,
+            hint: "HINT: The question is valid. To determine whether or not it is correct, please use magnifier to find the right answer. Remember, try to spend some time on each image based on the questions. Most questions are tricky!",
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000035287.jpg",
+            question: "How many people are skateboarding?",
+            isModelCorrect: true,
+            hint: "HINT: You should be able to clearly see 3 people skateboarding.",
+            isAnswer: false
+        },
+        {
+            imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000329753.jpg",
+            question: "What are the people waiting for?",
+            isModelCorrect: false,
+            isAnswer: false,
+            hint: "HINT: The image does not provide enough information to give a consistent answer to this question. If there is a bus stop on the image, then the question would be valid."
+        },
+    ]
+}
+
+const VQAQuizExamples = (mode) => {
+    if (mode === "creation") {
+        return creation_examples;
+    } else if (mode === "validation") {
+        return validation_examples;
     }
+}
 
 export { VQAQuizExamples }

--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/Examples/VQAValidInvalidExamples.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/Examples/VQAValidInvalidExamples.js
@@ -1,4 +1,4 @@
-const getVQAValidInvalidExamples = (mode) => [
+const creation_examples = [
     {
         imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000125542.jpg",
         question: "What is the capital of USA?",
@@ -43,7 +43,7 @@ const getVQAValidInvalidExamples = (mode) => [
         modelAns: "usa",
         userFeedback: ["Incorrect", "United Kingdom"],
         isValid: true,
-        explanation: `This example requires two basic steps, the first one is the identification of a flag in the image and the second is the process to determine what country corresponds to that flag. In this case the ${mode === "creation" ? "AI" : "answer"} was incorrect, so you are expected to enter the correct answer.`
+        explanation: `This example requires two basic steps, the first one is the identification of a flag in the image and the second is the process to determine what country corresponds to that flag. In this case the AI was incorrect, so you are expected to enter the correct answer.`
     },
     {
         imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000088527.jpg",
@@ -51,15 +51,15 @@ const getVQAValidInvalidExamples = (mode) => [
         modelAns: "striped",
         userFeedback: ["Correct", null],
         isValid: true,
-        explanation: `In this case ${mode === "creation" ? "the AI needs to look at the image and" : "looking at the image is needed to"} identify the tie. Then it has to characterize it. Other people would likely agree with the answer.`
+        explanation: `In this case the AI needs to look at the image and identify the tie. Then it has to characterize it. Other people would likely agree with the answer.`
     },
     {
-        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000274422.jpg",
-        question: "Does it appear to be winter in this photo?",
-        modelAns: "no",
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000317606.jpg",
+        question: "How is this coffee served?",
+        modelAns: "on plate",
         userFeedback: ["Correct", null],
         isValid: true,
-        explanation: `${mode === "creation" ? "Here the AI needs to have a basic understanding about seasons" : "In this case having a basic undestanding about seasons is needed to answer correctly"}. Based on the sunny weather and the fruits in the tree seen in the image a person would say that the season is not winter.`
+        explanation: `The question could make sense for both 'on plate' and 'black' to be the answer. Here the answer is technically correct. So even though you might not be expecting it, when the model's answer is sensible to the image you should consider the model as correct.`
     },
     {
         imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000209374.jpg",
@@ -67,9 +67,102 @@ const getVQAValidInvalidExamples = (mode) => [
         modelAns: "2",
         userFeedback: ["Correct", null],
         isValid: true,
-        explanation: `For these types of questions the answer will be a number. For this example ${mode === "creation" ? "the AI needs to classify the objects in the image" : "classifying the objects in the image is needed to get the correct answer"}. Although the vegetables at the bottom appear blurry it is possible to identify two different types of veggies.`
+        explanation: `For these types of questions the answer will be a number. For this example the AI needs to classify the objects in the image. Although the vegetables at the bottom appear blurry it is possible to identify two different types of veggies.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000274422.jpg",
+        question: "Does it appear to be winter in this photo?",
+        modelAns: "no",
+        userFeedback: ["Correct", null],
+        isValid: true,
+        explanation: `Here the AI needs to have a basic understanding about seasons. Based on the sunny weather and the fruits in the tree seen in the image a person would say that the season is not winter.`
+    },
+];
+
+const validation_examples = [
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000125542.jpg",
+        question: "What is the capital of USA?",
+        isValid: false,
+        explanation: "This question can be answered without looking at the image. Therefore, it is not a valid question."
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000375306.jpg",
+        question: "What is the woman people at?",
+        isValid: false,
+        explanation: `This question seems to not make sense in English. If you think most people will be confused by the question, then it is invalid.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/val2014/COCO_val2014_000000081922.jpg",
+        question: "How many cars are in the image?",
+        isValid: false,
+        explanation: "The image is not clear enough to give an answer to which most people will agree with."
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000274422.jpg",
+        question: "Does it appear to be winter in this photo?",
+        modelAns: "no",
+        userFeedback: ["Correct", null],
+        isValid: true,
+        explanation: `In this case having a basic undestanding about seasons is needed to answer correctly. Based on the sunny weather and the fruits in the tree seen in the image a person would say that the season is not winter.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000576597.jpg",
+        question: "What country is the flag from?",
+        modelAns: "usa",
+        userFeedback: ["Incorrect", "United Kingdom"],
+        isValid: true,
+        explanation: `This example requires two basic steps, the first one is the identification of a flag in the image and the second is the process to determine what country corresponds to that flag. In this case the answer was incorrect, so you are expected to enter the correct answer.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000088527.jpg",
+        question: "What is the pattern on the tie he is wearing?",
+        modelAns: "striped",
+        userFeedback: ["Correct", null],
+        isValid: true,
+        explanation: `In this case looking at the image is needed to identify the tie. Then it has to characterize it. Other people would likely agree with the answer.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/train2014/COCO_train2014_000000209374.jpg",
+        question: "How many types of veggies are in the image?",
+        modelAns: "2",
+        userFeedback: ["Correct", null],
+        isValid: true,
+        explanation: `For this example classifying the objects in the image is needed to get the correct answer. Although the vegetables at the bottom appear blurry it is possible to identify two different types of veggies.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/val2014/COCO_val2014_000000203697.jpg",
+        question: "How many watches are in the picture?",
+        modelAns: "2",
+        userFeedback: ["Incorrect", null],
+        isValid: true,
+        explanation: `You should always aim to give the questions the benefit of the doubt. After all, they are rated by people who are just like you. We encourage that you spend some time assuming that there is some people wearing a watch somewhere on the image, you can choose to use the magnifier feature by simply hover over the image to see a zoomed in version. We only see one person wearing a watch (please try to find it!), so the answer is incorrect.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000345888.jpg",
+        question: "What type of connection is needed to use the mouse?",
+        modelAns: "plastic",
+        userFeedback: ["Incorrect", null],
+        isValid: true,
+        explanation: `In this case, you can imagine the person asking this question is trying to get the answer 'USB'. However, the answer 'plastic' here is not the type of the connection, but the type of material. So the answer is incorrect.`
+    },
+    {
+        imageUrl: "https://dl.fbaipublicfiles.com/dynabench/coco/test2015/COCO_test2015_000000078067.jpg",
+        question: "What is the word embossed in the clamp closest to the Broadway street sign?",
+        modelAns: "broadway",
+        userFeedback: ["Incorrect", null],
+        isValid: true,
+        explanation: `This question is a bit tricky. (You will find most questions are tricky.) It does take a person a while to figure out the answer. So please do spend some time on each image and make sure you give them justice by investigating them with the image magnifier (just hover over the image)! Here the correct answer to the question is: bottom. (see if you can find it!)`
     },
 ]
+
+const getVQAValidInvalidExamples = (mode) => {
+    if (mode === "creation") {
+        return creation_examples;
+    } else if (mode === "validation") {
+        return validation_examples;
+    }
+}
 
 
 export default getVQAValidInvalidExamples

--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAQuiz.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAQuiz.js
@@ -15,7 +15,7 @@ class VQAQuiz extends React.Component {
     constructor(props) {
         super(props);
         this.MODEL_STATES = { "UNKNOWN" : -1, "CORRECT": 1, "INCORRECT": 0 };
-        this.examples = VQAQuizExamples;
+        this.examples = VQAQuizExamples(this.props.onboardingMode);
         this.minCorrectValidations = 6;
         this.maxAllowedAttempts = 2;
         this.state = this.props.cache || {

--- a/frontends/web/mturk-src/components/vqa/src/QuestionsCharacteristics.js
+++ b/frontends/web/mturk-src/components/vqa/src/QuestionsCharacteristics.js
@@ -50,6 +50,9 @@ class ValidQuestionCharacteristics extends React.Component {
                             <li>Invalid: What is the woman doing? (when there is no women or if there are multiple women each doing something different.)</li>
                             <li>Valid: What is the woman to the left of the man doing? (when there is only one woman that satisfies the criteria and it is clear another person will agree with your answer to the question.)</li>
                         </ul>
+                    <li>
+                        <b>Remember that most questions are tricky! Please use the image magnifier by hovering your mouse over the image to investigate.</b>
+                    </li>
                 </ul>
             </>
         )

--- a/frontends/web/mturk-src/components/vqa/src/VQAPreview.js
+++ b/frontends/web/mturk-src/components/vqa/src/VQAPreview.js
@@ -77,7 +77,7 @@ class VQAPreview extends React.Component {
                                 <ValidQuestionCharacteristics/>
                             </li>
                             <li>
-                                If it is, determine whether the provided answer is <b className="dark-blue-color">correct</b>.
+                                If the question is valid, determine whether the provided answer is <b className="dark-blue-color">correct</b>.
                             </li>
                         </ol>
                         <p>

--- a/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
@@ -143,8 +143,8 @@ class VQAValidationInterface extends React.Component {
             assignmentId: this.props.assignmentId,
 
             flagReason: this.state.flagReason,
-            questionValidationState: this.state.questionValidationState,
-            responseValidationState: this.state.responseValidationState,
+            questionValidationState: questionState,
+            responseValidationState: responseState,
             example_tags: this.getTagList(this.props)
         }
 
@@ -188,12 +188,14 @@ class VQAValidationInterface extends React.Component {
             <>
                 <p>
                     You will be shown an image and a question. The task consists of two rounds.
-                    First, you have to determine if the question is <b className="dark-blue-color">valid</b>.
+                    First, you have to determine if the question is <b className="dark-blue-color">valid</b>. Most of the questions should be valid, as they are produced by hardworking turkers like you!
+                    Some of the questions require digging into the image a bit more to assess its validity. As a reminder, you can use the magnifying glass by hovering your mouse over the image to zoom in!
+                    If we detect that you are labeling really quickly and not investigating the images in great detail, we will ban you.
                 </p>
                 <p>A question is considered <b>valid</b> if:</p>
                 <ValidQuestionCharacteristics/>
                 <p>
-                    After validating the question, next you will determine whether the provided answer is <b className="dark-blue-color">correct</b>.
+                    If you deem the question as valid, next you will determine whether the provided answer is <b className="dark-blue-color">correct</b>.
                     If you think the example should be reviewed, please click the <b>Flag</b> button and explain why
                     you flagged the example (try to use this sparingly). Please flag if you sense that the person asking the question
                     has a bad intent.


### PR DESCRIPTION
* Updated 1 example in the onboarding of the question collection to drive home to concept that if it is not possible to count the number of items (ie., if some of the items are blurry on the background), then the question is invalid.
* Mostly updated the validation interface to make it clear that:
1. Most questions are likely to be valid.
2. Make sure that they spend enough time to dig into the questions.
3. Explain how image magnifiers work.