### PR TITLE
Disable submit when flagged and no flag reason is specified.

### DIFF
--- a/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/VQAValidationInterface.js
@@ -231,7 +231,7 @@ class VQAValidationInterface extends React.Component {
         const INCORRECT = this.VALIDATION_STATES.INCORRECT
         const FLAGGED = this.VALIDATION_STATES.FLAGGED
         let disableSubmit = this.state.submitDisabled
-        if (this.state.questionValidationState === "flagged" && (this.state.flagReason === null || this.state.flagReason.length === 0)) {
+        if (this.state.questionValidationState === "flagged" && (this.state.flagReason === null || this.state.flagReason.trim().length === 0)) {
             disableSubmit = true
         }
         if (this.state.examplesOverError) {
@@ -383,7 +383,11 @@ class VQAValidationInterface extends React.Component {
                             callback: () => this.setState((state, props) => {return { showInstructions: !state.showInstructions }})
                         },
                         "enter": {
-                            callback: () => this.submitValidation()
+                            callback: () => {
+                                if (!disableSubmit) {
+                                    this.submitValidation()
+                                }
+                            }
                         }
                     }}
                 />


### PR DESCRIPTION
This PR disables submitting a validation in the vqa task when an example is flagged and no flag reason is specified.

Tested manually:

State:
1. Example is flagged and flag reason text box is empty, but focused.
    Action: Type Enter. No action takes place.
2. Example is flagged and flag reason text box is focused has only blank spaces.
   Action: Type Enter. No action takes place.
3. Example is flagged and there is a string with at least one character different from blank space.
   Action: Type Enter. Validation is submitted.