### PR TITLE
Increment fooled count when user checks the created example.

### DIFF
--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -150,8 +150,25 @@ def update_example(credentials, eid):
                 bottle.abort(403, "Access denied")
             del data["uid"]  # don't store this
 
+        if (
+            "model_wrong" in data
+            and data["model_wrong"] is True
+            and example.model_wrong is False
+        ):
+            cm = ContextModel()
+            rm = RoundModel()
+            context = cm.get(example.cid)
+            rm.updateLastActivity(context.r_realid)
+            rm.incrementFooledCount(context.r_realid)
+            if credentials["id"] != "turk":
+                um = UserModel()
+                info = RoundUserExampleInfoModel()
+                um.incrementFooledCount(example.uid)
+                info.incrementFooledCount(example.uid, context.r_realid)
+
         logger.info(f"Updating example {example.id} with {data}")
         em.update(example.id, data)
+
         if credentials["id"] != "turk":
             if "retracted" in data and data["retracted"] is True:
                 um = UserModel()

--- a/api/models/example.py
+++ b/api/models/example.py
@@ -94,7 +94,7 @@ class ExampleModel(BaseModel):
                 and "answer" in response
                 and "prob" in response
             ):
-                model_wrong = True
+                model_wrong = False
                 pred = str(response["answer"]) + "|" + str(float(response["prob"][0]))
             elif "model_is_correct" in response and "text" in response:
                 pred = str(response["model_is_correct"]) + "|" + str(response["text"])


### PR DESCRIPTION
This PR does two things:
- Sets `model_wrong` to `False` when a vqa example is created. Otherwise the `fooled_count` will be incremented without knowing if the model was actually fooled or not.
- Increments `fooled_count` both in user and round schemas when an example is updated indicating that the model was fooled.

Before this changes every example created was considered to be a fooling example and even when the user indicated that the model was correct, the count was not updated.

Tested manually:
- The example is created and the `fooled_count` is not incremented, only `total_collected`.
- User selects "Correct" -> `fooled_count` is not incremented.
- User selects "Incorrect" -> `fooled_count` is incremented in one unit in both user and round schemas.