### PR TITLE
Annotator cannot validate same example more than once.

### DIFF
--- a/api/models/example.py
+++ b/api/models/example.py
@@ -285,10 +285,27 @@ class ExampleModel(BaseModel):
                 )
             )
         )
-        if my_uid is not None and mode == "owner":
-            cnt_uid = db.sql.func.sum(
-                case([(Validation.uid == my_uid, 1)], else_=0)
-            ).label("cnt_uid")
+        if my_uid is not None:
+            if mode == "owner":
+                cnt_uid = db.sql.func.sum(
+                    case([(Validation.uid == my_uid, 1)], else_=0)
+                ).label("cnt_uid")
+            elif mode == "user":
+                result_partially_validated = result_partially_validated.filter(
+                    db.cast(Example.metadata_json, JSON)["annotator_id"] != my_uid
+                )
+                cnt_uid = db.sql.func.sum(
+                    case(
+                        [
+                            (
+                                db.cast(Validation.metadata_json, JSON)["annotator_id"]
+                                == my_uid,
+                                1,
+                            )
+                        ],
+                        else_=0,
+                    )
+                ).label("cnt_uid")
             result_partially_validated = result_partially_validated.group_by(
                 Validation.eid
             ).having(cnt_uid == 0)
@@ -300,11 +317,6 @@ class ExampleModel(BaseModel):
 
         if my_uid is not None and mode == "owner":
             result = result.filter(Example.uid != my_uid)
-
-        if my_uid is not None and mode == "user":
-            result = result.filter(
-                db.cast(Example.metadata_json, JSON)["annotator_id"] != my_uid
-            )
 
         result = (
             result.order_by(


### PR DESCRIPTION
This PR does not allow an annotator to validate the same example more than once.

Before returning a random example it checks that the annotator id of the validations related with this example is not the same as the annotator that is requesting the example. This specific change only affects the vqa validation task.

Test plan:
Tested locally. Randomly validated the examples stored locally until receiving the following error:
![image](https://user-images.githubusercontent.com/23566456/111568369-3cb76d00-8766-11eb-8d89-47058858b336.png)