### PR TITLE
Show validated fooling rate in overall task page.

### DIFF
--- a/api/models/round.py
+++ b/api/models/round.py
@@ -3,6 +3,7 @@
 import sqlalchemy as db
 
 from .base import Base, BaseModel
+from .validation import LabelEnum, Validation, ValidationModel
 
 
 class Round(Base):
@@ -96,3 +97,15 @@ class RoundModel(BaseModel):
         if r:
             r.task.last_updated = db.sql.func.now()
             self.dbs.commit()
+
+    def getValidationStats(self, tid, rid):
+        vm = ValidationModel()
+        validations = vm.getByTidAndRid(tid, rid)
+        total_validations = validations.count()
+        correct_validations = validations.filter(
+            Validation.label == LabelEnum.correct
+        ).count()
+        return {
+            "total_validations": total_validations,
+            "correct_validations": correct_validations,
+        }

--- a/api/models/task.py
+++ b/api/models/task.py
@@ -3,7 +3,7 @@
 import sqlalchemy as db
 
 from .base import Base, BaseModel
-from .round import Round
+from .round import Round, RoundModel
 from .user import User
 
 
@@ -106,7 +106,12 @@ class TaskModel(BaseModel):
                 .one()
             )
             t = t.to_dict()
-            t["round"] = r.to_dict()
+            r = r.to_dict()
+            rm = RoundModel()
+            validation_stats = rm.getValidationStats(tid, r["rid"])
+            r["total_validations"] = validation_stats["total_validations"]
+            r["correct_validations"] = validation_stats["correct_validations"]
+            t["round"] = r
             return t
         except db.orm.exc.NoResultFound:
             return False

--- a/api/models/validation.py
+++ b/api/models/validation.py
@@ -79,3 +79,20 @@ class ValidationModel(BaseModel):
             return self.dbs.query(Validation).filter(Validation.eid == eid)
         except db.orm.exc.NoResultFound:
             return False
+
+    def getByTidAndRid(self, tid, rid):
+        from models.example import Example
+        from models.context import Context
+        from models.round import Round
+
+        try:
+            return (
+                self.dbs.query(Validation)
+                .join(Example, Validation.eid == Example.id)
+                .join(Context, Example.cid == Context.id)
+                .join(Round, Context.r_realid == Round.id)
+                .filter(Round.tid == tid)
+                .filter(Round.rid == rid)
+            )
+        except db.orm.exc.NoResultFound:
+            return False

--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -248,6 +248,22 @@ const OverallTaskStats = (props) => {
             % )
           </td>
         </tr>
+        {props.task.round && (
+          <tr>
+            <td>Correct/Validated (Validated Model Error rate)</td>
+            <td>
+              {props.task.round?.correct_validations}/
+              {props.task.round?.total_validations} (
+              {props.task.round?.total_validations > 0
+                ? (
+                    (100 * props.task.round?.correct_validations) /
+                    props.task.round?.total_validations
+                  ).toFixed(2)
+                : "0.00"}
+              % )
+            </td>
+          </tr>
+        )}
         <tr>
           <td>Last activity:</td>
           <td>


### PR DESCRIPTION
This PR adds the validated fooling rate (correct_validations / total_validations) to the overall task page in the web interface.

The ratio is calculated based on the current round and the specific task.

![image](https://user-images.githubusercontent.com/23566456/111719894-6df57300-8822-11eb-81be-2bad77bf1eb3.png)

Test Plan:
- The round has no examples:
![image](https://user-images.githubusercontent.com/23566456/111720016-b745c280-8822-11eb-80f1-517e67ddeb49.png)
- The round has no correct examples:
![image](https://user-images.githubusercontent.com/23566456/111720231-1c011d00-8823-11eb-8c7c-b025e9860121.png)
- The round has validated examples and examples validated as "correct"
![image](https://user-images.githubusercontent.com/23566456/111720313-3b984580-8823-11eb-8ed4-b82ff9b9b007.png)


