### PR TITLE
Examples sub-page: show user fooling rate per task.

### DIFF
--- a/api/models/round_user_example_info.py
+++ b/api/models/round_user_example_info.py
@@ -123,3 +123,28 @@ class RoundUserExampleInfoModel(BaseModel):
         )
 
         return query_res.limit(n).offset(n * offset), util.get_query_count(query_res)
+
+    def getUserStats(self, r_realid, uid):
+        total_fooled_cnt = db.sql.func.sum(RoundUserExampleInfo.total_fooled).label(
+            "total_fooled_cnt"
+        )
+        total_verified_not_correct_fooled_cnt = db.sql.func.sum(
+            RoundUserExampleInfo.total_verified_not_correct_fooled
+        ).label("total_verified_not_correct_fooled_cnt")
+        examples_submitted_cnt = db.sql.func.sum(
+            RoundUserExampleInfo.examples_submitted
+        ).label("examples_submitted_cnt")
+        return (
+            self.dbs.query(
+                examples_submitted_cnt,
+                total_fooled_cnt,
+                total_verified_not_correct_fooled_cnt,
+            )
+            .filter(
+                db.and_(
+                    RoundUserExampleInfo.r_realid == r_realid,
+                    RoundUserExampleInfo.uid == uid,
+                )
+            )
+            .one()
+        )

--- a/api/models/task.py
+++ b/api/models/task.py
@@ -2,6 +2,8 @@
 
 import sqlalchemy as db
 
+from common import helpers as util
+
 from .base import Base, BaseModel
 from .round import Round, RoundModel
 from .user import User
@@ -96,6 +98,12 @@ class TaskModel(BaseModel):
         for ii, r in enumerate([x[1] for x in rows]):
             tasks[ii]["round"] = r.to_dict()
         return tasks
+
+    def getPaginated(self, n=5, offset=0):
+        query = self.dbs.query(Task).filter(Task.hidden.is_(False))
+        rows = query.limit(n).offset(offset * n).all()
+        tasks = [x.to_dict() for x in rows]
+        return tasks, util.get_query_count(query)
 
     def getWithRound(self, tid):
         try:

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -136,6 +136,17 @@ export default class ApiService {
     });
   }
 
+  getTaskStatsForUser(userId, limit, offset) {
+    return this.fetch(
+      `${this.domain}/tasks/users/${userId}?limit=${limit || 5}&offset=${
+        offset || 0
+      }`,
+      {
+        method: "GET",
+      }
+    );
+  }
+
   submitModel(data) {
     const token = this.getToken();
     const formData = new FormData();

--- a/frontends/web/src/containers/App.js
+++ b/frontends/web/src/containers/App.js
@@ -199,6 +199,9 @@ class App extends React.Component {
                         <NavDropdown.Item as={Link} to="/account#models">
                           Models
                         </NavDropdown.Item>
+                        <NavDropdown.Item as={Link} to="/account#examples">
+                          Examples
+                        </NavDropdown.Item>
                         <NavDropdown.Divider />
                         <NavDropdown.Item as={Link} to="/logout">
                           Logout


### PR DESCRIPTION
This PR is related to issue https://github.com/facebookresearch/dynabench/issues/107. 
It adds the ExamplesSubPage. This page shows a table with five columbs:
- The name of the task
- The the total count of examples submitted. 
- MER.
- vMER
- Action: Shows a button to export user's own examples.
- 
This page is paginated and it shows up to 10 tasks per page.

This PR is the first of two steps. In the second step when the user clicks the button, examples will be downloaded.
![image](https://user-images.githubusercontent.com/23566456/112699711-107caa00-8e52-11eb-99ab-abf7e5bccf3d.png)

Test Plan:
- If there are no examples, columns are filled with zeroes.
- Example sub-page pagination.
   - At the beginning the `Previous` button is disabled.
   - When the last task is reached the `Next` button is disabled.


https://user-images.githubusercontent.com/23566456/112700296-73227580-8e53-11eb-8c56-d0b7f3907b33.mov



