### PR TITLE
Export user's examples in the examples sub-page.

### DIFF
--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -389,12 +389,12 @@ export default class ApiService {
     );
   }
 
-  exportData(tid, rid = null) {
+  exportData(tid, rid = null, isOwnerRequest = true) {
     var export_link = `${this.domain}/tasks/${tid}`;
     if (rid !== null) {
       export_link += `/rounds/${rid}`;
     }
-    export_link += "/export";
+    export_link += `/export?mode=${isOwnerRequest ? "owner" : "user"}`;
     return this.fetch(export_link, {
       method: "GET",
     }).then((res) => {

--- a/frontends/web/src/containers/ProfilePage.js
+++ b/frontends/web/src/containers/ProfilePage.js
@@ -356,7 +356,7 @@ const ExamplesSubPage = (props) => {
               <tbody>
                 {props.tasksWithUserStats.map((taskWithUserStats) => {
                   return (
-                    <tr key={taskWithUserStats.task_shortname}>
+                    <tr key={taskWithUserStats.tid}>
                       <td className="blue-color">
                         {taskWithUserStats.task_shortname || "Unknown"}
                       </td>
@@ -366,9 +366,13 @@ const ExamplesSubPage = (props) => {
                       <td className="text-left">{taskWithUserStats.MER}%</td>
                       <td className="text-left">{taskWithUserStats.vMER}%</td>
                       <td className="text-center" width="200px">
-                        <BBadge variant="success" className="publishStatus">
+                        <Button
+                          className="bg-success"
+                          size="sm"
+                          onClick={() => props.export(taskWithUserStats.tid)}
+                        >
                           Export
-                        </BBadge>
+                        </Button>
                       </td>
                     </tr>
                   );
@@ -556,6 +560,10 @@ class ProfilePage extends React.Component {
         console.log(error);
       }
     );
+  };
+
+  exportUserExamplesInTask = (tid) => {
+    return this.context.api.exportData(tid, null, false);
   };
 
   componentDidUpdate(prevProps) {
@@ -852,6 +860,7 @@ class ProfilePage extends React.Component {
                 tasksWithUserStatsPage={this.state.tasksWithUserStatsPage}
                 isEndOfTasksWithUserStats={this.state.isEndOfTasksWithUserStats}
                 paginate={this.paginateTasksWithUserStats}
+                export={this.exportUserExamplesInTask}
               />
             ) : null}
             {this.props.location.hash === "#notifications" ? (


### PR DESCRIPTION
This PR is related to issue https://github.com/facebookresearch/dynabench/issues/107 and a continuation of https://github.com/facebookresearch/dynabench/pull/360.

A button to export only the examples created by the user was added to the examples sub-page.
![image](https://user-images.githubusercontent.com/23566456/112700639-34d98600-8e54-11eb-9501-779cbd8fa851.png)

The methods to export data for an owner user were reused. A flag indicating wether all the examples or only examples created by a specific user should be exported was added. This flag also determines wether the returned json should include `anon_uid` field in examples (when an owner is exporting data) or not (when is a user export). This way a task owner can export all the examples in the overall page and only examples created by him/her in the examples page.

This is a draft because the information that non task owner has access to has not been defined. Currently the only difference between exporting data as owner and non-owner are the examples downloaded. The former has access to all of them, the latter has access to examples created by hm/her as well as the corresponding validations. User id's are hidden with an `anon_uid`.

Test Plan:
- To prove that the examples downloaded in the examples sub-page belong only to the user exporting them, the number of elements downloaded should be the same number as the one indicated in the stats and less than the total amount of examples in the table.
![image](https://user-images.githubusercontent.com/23566456/111890335-23086680-89ae-11eb-831f-e087f3b76afe.png)
This is the total number of examples in a local db for VQA (created among web and mturk users).

![image](https://user-images.githubusercontent.com/23566456/112700786-897d0100-8e54-11eb-83fc-59193b1b8456.png)

- As shown in the table above, the test user has 156 examples in VQA.




