### PR TITLE
Added inspiration mode: show model fooling examples in CreateInterface

### DIFF
--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -61,6 +61,13 @@ def get_random_filtered_example(
     return util.json_encode(example)
 
 
+@bottle.get("/examples/<tid:int>/inspiration")
+def get_random_example_for_inspiration(tid):
+    em = ExampleModel()
+    fooling_example_with_context = em.getRandomFoolingExampleWithContext(tid)
+    return util.json_encode(fooling_example_with_context[0].to_dict())
+
+
 @bottle.get("/examples/<tid:int>/<rid:int>")
 @_auth.requires_auth_or_turk
 def get_random_example(credentials, tid, rid):

--- a/api/models/example.py
+++ b/api/models/example.py
@@ -238,6 +238,21 @@ class ExampleModel(BaseModel):
         except db.orm.exc.NoResultFound:
             return False
 
+    def getRandomFoolingExampleWithContext(self, tid, n=1):
+        try:
+            return (
+                self.dbs.query(Example)
+                .join(Context, Example.cid == Context.id)
+                .join(Round, Context.r_realid == Round.id)
+                .filter(Round.tid == tid)
+                .filter(Example.retracted == False)  # noqa
+                .filter(Example.model_wrong == True)
+                .order_by(db.sql.func.rand())
+                .limit(n)
+            )
+        except db.orm.exc.NoResultFound:
+            return False
+
     def getRandom(
         self,
         rid,

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -262,6 +262,12 @@ export default class ApiService {
     );
   }
 
+  getRandomExampleForInspiration(tid) {
+    return this.fetch(`${this.domain}/examples/${tid}/inspiration`, {
+      method: "GET",
+    });
+  }
+
   getRandomExample(tid, rid, tags = [], annotator_id = null) {
     let annotator_query = annotator_id ? `&annotator_id=${annotator_id}` : "";
     return this.fetch(

--- a/frontends/web/src/containers/FoolingExampleCard.js
+++ b/frontends/web/src/containers/FoolingExampleCard.js
@@ -1,0 +1,98 @@
+import React from "react";
+import { Card, Row, Col } from "react-bootstrap";
+
+const FoolingExampleCard = (props) => {
+  const mapExampleTypeToTasks = {
+    question: ["QA", "VQA"],
+    statement: ["Sentiment", "Hate Speech"],
+    hypoythesis: ["NLI"],
+  };
+
+  const capitalizeFirstLetter = (word) => {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  };
+
+  const getExampleType = (taskShortname) => {
+    const exampleTypes = Object.keys(mapExampleTypeToTasks);
+    for (let i = 0; i < exampleTypes.length; i++) {
+      let type = exampleTypes[i];
+      if (mapExampleTypeToTasks[type].includes(taskShortname)) {
+        return capitalizeFirstLetter(type);
+      }
+    }
+    return "Statement";
+  };
+
+  const getModelPredictionsText = () => {
+    const taskType = props.task.type;
+    let modelPreds = props.example.model_preds.split("|");
+    if (taskType == "clf") {
+      modelPreds = modelPreds.map((strProb) => parseFloat(strProb));
+      const modelPredIdx = modelPreds.indexOf(Math.max(...modelPreds));
+      return props.task.targets[modelPredIdx];
+    } else if (taskType === "extract") {
+      return modelPreds[1];
+    } else if (taskType === "VQA") {
+      return modelPreds[0];
+    }
+  };
+
+  const getAnnotatorProposedAnswer = () => {
+    if (props.task.type === "clf")
+      return props.task.targets[parseInt(props.example.target_pred)];
+    return props.example.target_pred;
+  };
+
+  return (
+    <Card className="hypothesis rounded border m-3 card">
+      <Card.Body className="p-3">
+        <Row>
+          <Col xs={12} md={7}>
+            <h6 className="text-uppercase dark-blue-color spaced-header">
+              {getExampleType(props.task.shortname)}
+            </h6>
+            {<p>{props.example.text}</p>}
+            <h6 className="text-uppercase dark-blue-color spaced-header">
+              Model predictions
+            </h6>
+            <p>{getModelPredictionsText()}</p>
+            <h6 className="text-uppercase dark-blue-color spaced-header">
+              Annotator's proposed answer
+            </h6>
+            <p>{getAnnotatorProposedAnswer()}</p>
+            {props.example.example_explanation && (
+              <>
+                <h6 className="text-uppercase dark-blue-color spaced-header">
+                  Example explanation{" "}
+                  <small>(why target label is correct)</small>
+                </h6>
+                <p>{props.example.example_explanation}</p>
+              </>
+            )}
+            {props.example.model_explanation && (
+              <>
+                <h6 className="text-uppercase dark-blue-color spaced-header">
+                  Model explanation <small>( why model was fooled )</small>
+                </h6>
+                <p>{props.example.model_explanation}</p>
+              </>
+            )}
+            {props.example.metadata_json &&
+              JSON.parse(props.example.metadata_json).hasOwnProperty(
+                "hate_type"
+              ) && (
+                <>
+                  <h6 className="text-uppercase dark-blue-color spaced-header">
+                    Hate Target:
+                  </h6>
+                  <p>{JSON.parse(props.example.metadata_json).hate_type}</p>
+                </>
+              )}
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export { FoolingExampleCard };

--- a/frontends/web/src/containers/ModeDropdown.js
+++ b/frontends/web/src/containers/ModeDropdown.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { DropdownButton, Dropdown } from "react-bootstrap";
+
+const ModeDropdown = ({ selectedMode, onClick }) => {
+  const modesProps = {
+    live: {
+      variant: "primary",
+      icon: "fa fa-brain",
+      name: "Live Mode",
+    },
+    inspiration: {
+      variant: "info",
+      icon: "fa fa-lightbulb",
+      name: "Inspiration",
+    },
+    sandbox: {
+      variant: "warning",
+      icon: "fa fa-exclamation-triangle",
+      name: "Sandbox",
+    },
+  };
+
+  return (
+    <DropdownButton
+      variant={modesProps[selectedMode].variant}
+      className="p-1"
+      title={
+        <>
+          <i className={modesProps[selectedMode].icon} />
+          &nbsp; {modesProps[selectedMode].name}
+        </>
+      }
+    >
+      {Object.keys(modesProps).map((mode, index) => (
+        <Dropdown.Item data={mode} onClick={onClick} key={index}>
+          {modesProps[mode].name}
+        </Dropdown.Item>
+      ))}
+    </DropdownButton>
+  );
+};
+
+export { ModeDropdown };


### PR DESCRIPTION
This PR is related to https://github.com/facebookresearch/dynabench/issues/106.

It introduces the Inspiration mode. In Inspiration mode model fooling examples are shown to the user so he/she can get an idea of the type of examples that should be created. Live and Sandbox modes where added together with the Inspiration mode in a dropdown button.
![image](https://user-images.githubusercontent.com/23566456/111946373-fd0fbe80-8aa0-11eb-8e74-b8efb14ec2c7.png)

The information shown is:
- The example itself (statement, hypothesis or question).
- The model's answer.
- The answer proposed by the annotator who created the example.
- An explanation of what the proposed answer is the correct answer (if it exists).
- An explanation of why the model was fooled (if it exists).

![image](https://user-images.githubusercontent.com/23566456/111949032-9d67e200-8aa5-11eb-9c20-f813784e2199.png)

Test plan:
-When Inspiration mode is selected:
   -The `Submit` and `Switch Context` buttons are hidden and replaced with the `Next Example` button. 
   -The Rounds dropdown button, example input box and GoalMessage are hidden
   -Examples explanations are shown only when they have a value different from null.
-When sandbox mode is selected:
   -Examples are not stored in DB.
   -Warning indicating sandbox mode is shown.
-Live mode is selected:
   -If user is not logged in, the log in page is showed.
   -Examples are stored in db.
   -No warnings are shown.

https://user-images.githubusercontent.com/23566456/111952867-6268ad00-8aab-11eb-862b-01bd42cfaba8.mov
