### PR TITLE
Added eslint dependency to pre-commit hooks. Ran eslint with autofix.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,8 +68,9 @@ repos:
     rev: v7.21.0
     hooks:
     -   id: eslint
-        args: [--fix]
+        args: [--fix --silent]
         files: \.[jt]sx?$
         types: [file]
         additional_dependencies:
+            - eslint@7.21.0
             - eslint-config-react-app

--- a/frontends/web/src/components/TaskLeaderboard/OldTaskLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/OldTaskLeaderboardCard.js
@@ -48,7 +48,7 @@ const OldTaskLeaderboardCard = (props) => {
     fetchOverallModelLeaderboard(context.api, page);
     setIsLoading(false);
     return () => {};
-  }, [page]);
+  }, [context.api, fetchOverallModelLeaderboard, page]);
 
   if (!data) {
     return null;

--- a/frontends/web/src/components/TaskLeaderboard/TaskLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskLeaderboardCard.js
@@ -156,7 +156,14 @@ const TaskLeaderboardCard = (props) => {
     fetchOverallModelLeaderboard(context.api, page);
     setIsLoading(false);
     return () => {};
-  }, [page, sort, metrics, datasetWeights]);
+  }, [
+    page,
+    sort,
+    metrics,
+    datasetWeights,
+    fetchOverallModelLeaderboard,
+    context.api,
+  ]);
 
   const isEndOfPage = (page + 1) * pageLimit >= total;
 


### PR DESCRIPTION
Added `eslint@7.21.0` dependency to pre-commit hooks. This was detected to be necessary to run eslint hook. All the js linters where run in all the files again with autofix.

Tests:
![image](https://user-images.githubusercontent.com/23566456/112132761-8f42c000-8b90-11eb-890f-3974827edfae.png)
