### PR TITLE
Fixed race conditions in VQAOnboarder component.

### DIFF
--- a/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAOnboarder.js
+++ b/frontends/web/mturk-src/components/vqa/src/Onboarding/VQAOnboarder.js
@@ -21,27 +21,32 @@ class VQAOnboarder extends React.Component {
   }
 
   nextPhase = () => {
-    if (this.state.currPhase < this.totalPhases - 1) {
-      this.setState((state) => {
-        return { currPhase: state.currPhase + 1 };
-      });
-    }
+    this.setState(function (prevState, _) {
+      if (prevState.currPhase < this.totalPhases - 1) {
+        return { currPhase: prevState.currPhase + 1 };
+      }
+      return {};
+    });
   };
 
   prevPhase = () => {
-    if (this.state.currPhase > 0) {
-      this.setState((state) => {
-        return { currPhase: state.currPhase - 1 };
-      });
-    }
+    this.setState(function (prevState, _) {
+      if (prevState.currPhase > 0) {
+        return { currPhase: prevState.currPhase - 1 };
+      }
+      return {};
+    });
   };
 
   setPhaseCompleted = () => {
-    if (!this.state.phasesCompleted[this.state.currPhase]) {
-      let updatedPhasesStatus = this.state.phasesCompleted;
-      updatedPhasesStatus[this.state.currPhase] = true;
-      this.setState({ phasesCompleted: updatedPhasesStatus });
-    }
+    this.setState(function (prevState, _) {
+      if (!prevState.phasesCompleted[prevState.currPhase]) {
+        let updatedPhasesStatus = prevState.phasesCompleted;
+        updatedPhasesStatus[prevState.currPhase] = true;
+        return { phasesCompleted: updatedPhasesStatus };
+      }
+      return {};
+    });
   };
 
   submitOnboarding = (status) => {


### PR DESCRIPTION
This PR aims to fix some potential race conditions in the `VQAOnboarder` component (the one in charge of coordinating the different phases in Onboarding for VQA).

Tested locally:
- `Next Phase` button appears automatically to go from phase one to phase 2.
- `Next Phase` button is showed in phase two until the user has gone through all the examples.
- If the user makes modifications to the quiz in phase 3 (e.g it fails one attempt), and then the previous button is clicked, the state of the quiz is saved, so when the user comes back to the quiz the last state is restored (it remembers that the user already failed an attempt).
- Quiz is passed in first or second attempt --> user is redirected to main task.
- Quiz is failed --> user has no access to main task.