### PR TITLE
Added inspiration button: show verified model fooling examples in current round.

### DIFF
--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -61,6 +61,23 @@ def get_random_filtered_example(
     return util.json_encode(example)
 
 
+@bottle.get("/examples/<tid:int>/<rid:int>/inspiration")
+def get_verified_fooling_examples(tid, rid):
+    tm = TaskModel()
+    task = tm.get(tid)
+    num_matching_validations = 3
+    if task.settings_json:
+        settings = json.loads(task.settings_json)
+        num_matching_validations = settings["num_matching_validations"]
+
+    em = ExampleModel()
+    examples = em.getRandomVerifiedCorrect(tid, rid, num_matching_validations)
+    if not examples or len(examples) == 0:
+        bottle.abort(500, f"No examples available ({rid})")
+    example_dicts = [e.to_dict() for e in examples]
+    return util.json_encode(example_dicts)
+
+
 @bottle.get("/examples/vqa/<tid:int>/<rid:int>")
 @_auth.requires_auth_or_turk
 def get_random_example_vqa(credentials, tid, rid):

--- a/api/models/example.py
+++ b/api/models/example.py
@@ -312,6 +312,48 @@ class ExampleModel(BaseModel):
         except db.orm.exc.NoResultFound:
             return False
 
+    def getRandomVerifiedCorrect(self, tid, rid, num_matching_validations, n=5):
+        cnt_correct = db.sql.func.sum(
+            case([(Validation.label == LabelEnum.correct, 1)], else_=0)
+        ).label("cnt_correct")
+        cnt_owner_correct_validated = db.sql.func.sum(
+            case(
+                [
+                    (
+                        db.and_(
+                            Validation.mode == ModeEnum.owner,
+                            Validation.label == LabelEnum.correct,
+                        ),
+                        1,
+                    )
+                ],
+                else_=0,
+            )
+        ).label("cnt_owner_correct_validated")
+        try:
+            return (
+                self.dbs.query(Example)
+                .join(Context, Example.cid == Context.id)
+                .join(Round, Context.r_realid == Round.id)
+                .filter(Round.tid == tid)
+                .filter(Round.rid == rid)
+                .filter(Example.retracted == False)  # noqa
+                .filter(Example.model_wrong == True)
+                .join(Validation, Example.id == Validation.eid)
+                .group_by(Validation.eid)
+                .having(
+                    db.or_(
+                        cnt_correct >= num_matching_validations,
+                        cnt_owner_correct_validated > 0,
+                    )
+                )
+                .order_by(db.sql.func.rand())
+                .limit(n)
+                .all()
+            )
+        except db.orm.exc.NoResultFound:
+            return False
+
     def getRandom(
         self,
         rid,

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -278,6 +278,12 @@ export default class ApiService {
     });
   }
 
+  getVerifiedModelFoolingExamples(tid, rid) {
+    return this.fetch(`${this.domain}/examples/${tid}/${rid}/inspiration`, {
+      method: "GET",
+    });
+  }
+
   getRandomContext(tid, rid, tags = [], method = "min") {
     return this.fetch(
       `${

--- a/frontends/web/src/containers/App.css
+++ b/frontends/web/src/containers/App.css
@@ -251,3 +251,19 @@ table.inspectModel thead td {
         opacity: 1;
     }
 }
+
+.carousel-control-next {
+    display: inline-block;
+    margin-right: -60px;
+    margin-top: 0;
+    top: 50%;
+    filter: invert(100%);
+}
+
+.carousel-control-prev {
+    display: inline-block;
+    margin-left: -60px;
+    margin-top: 0;
+    top: 50%;
+    filter: invert(100%);
+}

--- a/frontends/web/src/containers/FoolingExampleCard.js
+++ b/frontends/web/src/containers/FoolingExampleCard.js
@@ -1,0 +1,115 @@
+import React from "react";
+import AtomicImage from "./AtomicImage.js";
+import { Card, Row, Col } from "react-bootstrap";
+
+const FoolingExampleCard = (props) => {
+  const mapExampleTypeToTasks = {
+    question: ["QA", "VQA"],
+    statement: ["Sentiment", "Hate Speech"],
+    hypoythesis: ["NLI"],
+  };
+
+  const capitalizeFirstLetter = (word) => {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  };
+
+  const getExampleType = (taskShortname) => {
+    const exampleTypes = Object.keys(mapExampleTypeToTasks);
+    for (let i = 0; i < exampleTypes.length; i++) {
+      let type = exampleTypes[i];
+      if (mapExampleTypeToTasks[type].includes(taskShortname)) {
+        return capitalizeFirstLetter(type);
+      }
+    }
+    return "Statement";
+  };
+
+  const getModelPredictionsText = () => {
+    const taskType = props.task.type;
+    let modelPreds = props.example.model_preds.split("|");
+    if (taskType == "clf") {
+      modelPreds = modelPreds.map((strProb) => parseFloat(strProb));
+      const modelPredIdx = modelPreds.indexOf(Math.max(...modelPreds));
+      return props.task.targets[modelPredIdx];
+    } else if (taskType === "extract") {
+      return modelPreds[1];
+    } else if (taskType === "VQA") {
+      return modelPreds[0];
+    }
+  };
+
+  const getAnnotatorProposedAnswer = () => {
+    if (props.task.type === "clf")
+      return props.task.targets[parseInt(props.example.target_pred)];
+    return props.example.target_pred;
+  };
+
+  return (
+    <Card className="d-flex justify-content-center overflow-hidden">
+      {props.task.has_context &&
+        (props.task.type === "VQA" ? (
+          <AtomicImage
+            src={props.example.context.context}
+            maxHeight={400}
+            maxWidth={600}
+          />
+        ) : (
+          <div className="mb-1 p-3 light-gray-bg">
+            {props.example.context.context.replace("<br>", "\n")}
+          </div>
+        ))}
+      <Card.Body>
+        <Card className="hypothesis rounded border m-3 card">
+          <Card.Body className="p-3">
+            <Row>
+              <Col>
+                <h6 className="text-uppercase dark-blue-color spaced-header">
+                  {getExampleType(props.task.shortname)}
+                </h6>
+                {<p>{props.example.text}</p>}
+                <h6 className="text-uppercase dark-blue-color spaced-header">
+                  Model predictions
+                </h6>
+                <p>{getModelPredictionsText()}</p>
+                <h6 className="text-uppercase dark-blue-color spaced-header">
+                  Annotator's proposed answer
+                </h6>
+                <p>{getAnnotatorProposedAnswer()}</p>
+                {props.example.example_explanation && (
+                  <>
+                    <h6 className="text-uppercase dark-blue-color spaced-header">
+                      Example explanation{" "}
+                      <small>(why target label is correct)</small>
+                    </h6>
+                    <p>{props.example.example_explanation}</p>
+                  </>
+                )}
+                {props.example.model_explanation && (
+                  <>
+                    <h6 className="text-uppercase dark-blue-color spaced-header">
+                      Model explanation <small>( why model was fooled )</small>
+                    </h6>
+                    <p>{props.example.model_explanation}</p>
+                  </>
+                )}
+                {props.example.metadata_json &&
+                  JSON.parse(props.example.metadata_json).hasOwnProperty(
+                    "hate_type"
+                  ) && (
+                    <>
+                      <h6 className="text-uppercase dark-blue-color spaced-header">
+                        Hate Target:
+                      </h6>
+                      <p>{JSON.parse(props.example.metadata_json).hate_type}</p>
+                    </>
+                  )}
+              </Col>
+            </Row>
+          </Card.Body>
+        </Card>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export { FoolingExampleCard };

--- a/frontends/web/src/containers/FoolingExamplesCarousel.js
+++ b/frontends/web/src/containers/FoolingExamplesCarousel.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { Carousel, Container } from "react-bootstrap";
+import { FoolingExampleCard } from "./FoolingExampleCard.js";
+
+class FoolingExamplesCarousel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      curIdx: 0,
+    };
+  }
+
+  handleSelect = (selectedIndex) => {
+    this.setState({
+      currIdx: selectedIndex,
+    });
+  };
+
+  render() {
+    const exampleCards = this.props.examples.map((example) => (
+      <Carousel.Item key={example.id}>
+        <FoolingExampleCard example={example} task={this.props.task} />
+      </Carousel.Item>
+    ));
+    return (
+      <Carousel
+        activeIndex={this.state.currIdx}
+        interval={null}
+        wrap={false}
+        onSelect={this.handleSelect}
+        className="px-3"
+      >
+        {exampleCards}
+      </Carousel>
+    );
+  }
+}
+
+export { FoolingExamplesCarousel };


### PR DESCRIPTION
This PR adds an inspiration button in the UI to create examples in the web interface. When the button is clicked a modal containing verified model fooling examples in the selected round is shown. By default, up to 5 examples are included and they are randomly returned. When there are no verified examples in the round the button is not shown.


https://user-images.githubusercontent.com/23566456/112365746-9c010a00-8c9d-11eb-92d4-a6ee7c641060.mov

Tests:
- Examples shown have a number of correct validations greater or equal to `num_matching_validations` or were verified by a task owner.
- Examples are randomly returned.
- Different examples are shown depending on the round selected.
- If no examples are returned the inspiration button is not shown