### PR TITLE
Moved weight sliders to table header

### DIFF
--- a/frontends/web/src/components/TaskLeaderboard/OverallModelLeaderBoard.js
+++ b/frontends/web/src/components/TaskLeaderboard/OverallModelLeaderBoard.js
@@ -1,4 +1,11 @@
-import { Form, OverlayTrigger, Popover } from "react-bootstrap";
+import {
+  Form,
+  OverlayTrigger,
+  Popover,
+  Container,
+  Row,
+  Col,
+} from "react-bootstrap";
 import React from "react";
 import { useState, useRef } from "react";
 import { Table } from "react-bootstrap";
@@ -29,12 +36,11 @@ const ChevronExpandButton = ({ expanded }) => {
  */
 const WeightSlider = ({ weight, onWeightChange }) => {
   return (
-    <Form className="d-flex ml-2 float-right" style={{ width: "50%" }}>
+    <Form className="d-flex ml-2 float-right">
       <Form.Control
         type="range"
         className="flex-grow-1"
         size="sm"
-        style={{ width: "50%" }}
         min={0}
         max={5}
         value={weight}
@@ -223,14 +229,6 @@ const OverallModelLeaderboardRow = ({
                       <WeightIndicator weight={weight} />
                     </span>
                   </WeightPopover>
-                  {enableWeights && (
-                    <WeightSlider
-                      weight={weight}
-                      onWeightChange={(newWeight) => {
-                        setDatasetWeight(dataset.id, newWeight);
-                      }}
-                    />
-                  )}
                 </div>
               </td>
               {dataset.scores &&
@@ -345,7 +343,7 @@ const OverallModelLeaderBoard = ({
               </SortContainer>
             </th>
           )}
-          {enableWeights && <th className="align-bottom">Adjust Weights</th>}
+          {enableWeights && <th className="align-top">Metric Weights</th>}
 
           {metrics?.map((metric) => {
             return (
@@ -374,6 +372,41 @@ const OverallModelLeaderBoard = ({
             </SortContainer>
           </th>
         </tr>
+        {enableWeights && (
+          <tr>
+            <th className="align-top">Dataset Weights</th>
+            <th colSpan={metrics.length}>
+              <Container fluid className="px-0">
+                <Row>
+                  {datasetWeights?.map((dataset) => {
+                    return (
+                      <Col xs={12} sm={6} md={3}>
+                        <WeightPopover
+                          label={dataset.name}
+                          weight={dataset.weight}
+                        >
+                          <span className="d-flex align-items-center justify-content-end">
+                            {dataset.name}&nbsp;
+                            <WeightIndicator weight={dataset.weight} />
+                          </span>
+                        </WeightPopover>
+                        <div>
+                          <WeightSlider
+                            weight={dataset.weight}
+                            onWeightChange={(newWeight) => {
+                              setDatasetWeight(dataset.id, newWeight);
+                            }}
+                          />
+                        </div>
+                      </Col>
+                    );
+                  })}
+                </Row>
+              </Container>
+            </th>
+            <th />
+          </tr>
+        )}
       </thead>
       <tbody>
         {models?.map((model) => (

--- a/frontends/web/src/components/TaskLeaderboard/TaskLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskLeaderboardCard.js
@@ -35,7 +35,7 @@ const TaskLeaderboardCard = (props) => {
   // Dataset Weights Array of a set of dataset id and corresponding weight.
   const [datasetWeights, setDatasetWeights] = useState(
     task.ordered_datasets?.map((ds) => {
-      return { id: ds.id, weight: 5 }; // Default weight to max i.e. 5.
+      return { id: ds.id, weight: 5, name: ds.name }; // Default weight to max i.e. 5.
     })
   );
 
@@ -108,62 +108,56 @@ const TaskLeaderboardCard = (props) => {
     });
   };
 
-  /**
-   * Invoke APIService to fetch leader board data
-   *
-   * @param {*} api instance of @see APIService
-   * @param {number} page
-   */
-  const fetchOverallModelLeaderboard = (api, page) => {
-    const metricSum = metrics?.reduce((acc, entry) => acc + entry.weight, 0);
-    const orderedMetricWeights = metrics?.map((entry) =>
-      metricSum === 0 ? 0.0 : entry.weight / metricSum
-    );
-    const dataSetSum = datasetWeights?.reduce(
-      (acc, entry) => acc + entry.weight,
-      0
-    );
-    const orderedDatasetWeights = datasetWeights?.map((entry) =>
-      dataSetSum === 0 ? 0.0 : entry.weight / dataSetSum
-    );
-
-    api
-      .getDynaboardScores(
-        taskId,
-        pageLimit,
-        page * pageLimit,
-        sort.field,
-        sort.direction,
-        orderedMetricWeights,
-        orderedDatasetWeights
-      )
-      .then(
-        (result) => {
-          setData(result.data);
-          setTotal(result.count);
-        },
-        (error) => {
-          console.log(error);
-        }
-      );
-  };
-
   const context = useContext(UserContext);
 
   // Call api on sort, page and weights changed.
   useEffect(() => {
+    /**
+     * Invoke APIService to fetch leader board data
+     *
+     * @param {*} api instance of @see APIService
+     * @param {number} page
+     */
+    const fetchOverallModelLeaderboard = (api, page) => {
+      const metricSum = metrics?.reduce((acc, entry) => acc + entry.weight, 0);
+      const orderedMetricWeights = metrics?.map((entry) =>
+        metricSum === 0 ? 0.0 : entry.weight / metricSum
+      );
+      const dataSetSum = datasetWeights?.reduce(
+        (acc, entry) => acc + entry.weight,
+        0
+      );
+      const orderedDatasetWeights = datasetWeights?.map((entry) =>
+        dataSetSum === 0 ? 0.0 : entry.weight / dataSetSum
+      );
+
+      api
+        .getDynaboardScores(
+          taskId,
+          pageLimit,
+          page * pageLimit,
+          sort.field,
+          sort.direction,
+          orderedMetricWeights,
+          orderedDatasetWeights
+        )
+        .then(
+          (result) => {
+            setData(result.data);
+            setTotal(result.count);
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+    };
+
     setIsLoading(true);
+
     fetchOverallModelLeaderboard(context.api, page);
     setIsLoading(false);
     return () => {};
-  }, [
-    page,
-    sort,
-    metrics,
-    datasetWeights,
-    fetchOverallModelLeaderboard,
-    context.api,
-  ]);
+  }, [page, sort, metrics, datasetWeights, context.api, taskId, pageLimit]);
 
   const isEndOfPage = (page + 1) * pageLimit >= total;
 


### PR DESCRIPTION
Moved dataset weight sliders to the top of the table 

![image](https://user-images.githubusercontent.com/77747478/112374366-64ec2200-8cb8-11eb-839a-5ec0f925fdf9.png)

Note: The weights per row are responsive and can support a variable number of datasets

![image](https://user-images.githubusercontent.com/77747478/112374623-b5637f80-8cb8-11eb-81e7-3e08c8053fc5.png)
