### PR TITLE
[Optimization] Do not include checkpoint in docker image since it is in the model archive

### DIFF
--- a/builder/utils/deployer.py
+++ b/builder/utils/deployer.py
@@ -16,8 +16,8 @@ from sagemaker.predictor import Predictor
 from tqdm import tqdm
 
 from deploy_config import deploy_config
-from utils.logging import logger
 from dynalab_cli.utils import SetupConfigHandler
+from utils.logging import logger
 
 
 class ModelDeployer:
@@ -167,9 +167,11 @@ class ModelDeployer:
         for f in os.listdir(docker_dir):
             shutil.copyfile(os.path.join(docker_dir, f), os.path.join(self.root_dir, f))
 
-        # tarball current folder but exclude checkpoints 
+        # tarball current folder but exclude checkpoints
         exclude_list_file = "exclude.txt"
-        self.config_handler.write_exclude_filelist(exclude_list_file, self.name, exclude_model=True)
+        self.config_handler.write_exclude_filelist(
+            exclude_list_file, self.name, exclude_model=True
+        )
         process = subprocess.run(
             [
                 "tar",
@@ -312,9 +314,7 @@ class ModelDeployer:
             "-f",
         ]
         if self.config["model_files"]:
-            extra_files = ",".join(
-                shlex.quote(f) for f in self.config["model_files"]
-            )
+            extra_files = ",".join(shlex.quote(f) for f in self.config["model_files"])
             archive_command += ["--extra-files", extra_files]
         process = subprocess.run(
             archive_command,


### PR DESCRIPTION
And a BE fix to make files in setup config a list rather than string

linked to Dynalab: https://github.com/facebookresearch/dynalab/pull/41

While my model is only 1.6K out of 16M total folder size, on ECR my docker size reduced from 1352MB to 1335MB, i.e. roughly 20MB save for 1.6K checkpoint. The save should be much more significant for a real model. 