### PR TITLE
fix for multiple loads of the api

### DIFF
--- a/frontends/web/src/components/TaskLeaderboard/OldTaskLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/OldTaskLeaderboardCard.js
@@ -19,36 +19,36 @@ const OldTaskLeaderboardCard = (props) => {
 
   const taskId = props.taskId;
 
-  const fetchOverallModelLeaderboard = (api, page) => {
-    api
-      .getOverallModelLeaderboard(
-        taskId,
-        props.location.hash.replace("#", ""),
-        10,
-        page
-      )
-      .then(
-        (result) => {
-          // const isEndOfPage = (page + 1) * this.state.pageLimit >= result.count;
-          setData(result.data);
-          setTags(result.leaderboard_tags);
-        },
-        (error) => {
-          console.log(error);
-        }
-      );
-  };
-
   const paginate = (component, state) => {};
 
   const context = useContext(UserContext);
 
   useEffect(() => {
+    const fetchOverallModelLeaderboard = (api, page) => {
+      api
+        .getOverallModelLeaderboard(
+          taskId,
+          props.location.hash.replace("#", ""),
+          10,
+          page
+        )
+        .then(
+          (result) => {
+            // const isEndOfPage = (page + 1) * this.state.pageLimit >= result.count;
+            setData(result.data);
+            setTags(result.leaderboard_tags);
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+    };
+
     setIsLoading(true);
     fetchOverallModelLeaderboard(context.api, page);
     setIsLoading(false);
     return () => {};
-  }, [context.api, fetchOverallModelLeaderboard, page]);
+  }, [context.api, page, props.location.hash, taskId]);
 
   if (!data) {
     return null;


### PR DESCRIPTION
Fixes the multi API load issue when the new dynaboard has been disabled. 

Network Log after fix: Only 1 call for the old api "/models..."
![image](https://user-images.githubusercontent.com/77747478/113361419-f0e5f580-9319-11eb-9b2d-32b2f46ac83b.png)
