### PR TITLE
[feat]: separate out the get context with failed validation api call from get_least_fooled

### DIFF
--- a/annotators/run_mturk.py
+++ b/annotators/run_mturk.py
@@ -40,6 +40,7 @@ class DynaBenchConfig:
     round_id: int = 0
     block_mobile: Optional[bool] = True
     fetching_tags: Optional[str] = None
+    fetching_method: Optional[str] = None
     # ; separating dictionary keys;
     # comma separating list items;
     # ie., "key:value0,value1,value2;key2:value4"
@@ -105,8 +106,7 @@ def main(cfg: DictConfig) -> None:
     def is_onboarding_successful(onboarding_data):
         if "outputs" not in onboarding_data:
             return False
-        if onboarding_data["outputs"] is None:
-            return False
+
         if "success" not in onboarding_data["outputs"]:
             return False
 

--- a/api/controllers/contexts.py
+++ b/api/controllers/contexts.py
@@ -37,6 +37,13 @@ def getRandomMinLeastFooledContext(tid, rid):
     return _getContext(tid, rid, "least_fooled", tags=tags)
 
 
+@bottle.get("/contexts/<tid:int>/<rid:int>/validation_failed")
+def getRandomValidationFailedContext(tid, rid):
+    query_dict = parse_qs(bottle.request.query_string)
+    tags = _getTags(query_dict)
+    return _getContext(tid, rid, "validation_failed", tags=tags)
+
+
 def _getTags(query_dict):
     tags = None
     if "tags" in query_dict and len(query_dict["tags"]) > 0:
@@ -54,13 +61,15 @@ def _getContext(tid, rid, method="min", tags=None):
     elif method == "min":
         context = c.getRandomMin(round.id, n=1, tags=tags)
     elif method == "least_fooled":
+        context = c.getRandomLeastFooled(round.id, n=1, tags=tags)
+    elif method == "validation_failed":
         tm = TaskModel()
         task = tm.get(tid)
         num_matching_validations = 3
         if task.settings_json:
             settings = json.loads(task.settings_json)
             num_matching_validations = settings["num_matching_validations"]
-        context = c.getRandomLeastFooled(
+        context = c.getRandomValidationFailed(
             round.id, num_matching_validations, n=1, tags=tags
         )
     if not context:

--- a/frontends/web/mturk-src/components/vqa/src/CreateVQAMturkInterface.js
+++ b/frontends/web/mturk-src/components/vqa/src/CreateVQAMturkInterface.js
@@ -184,7 +184,7 @@ class CreateVQAMturkInterface extends React.Component {
           this.props.taskConfig.task_id,
           this.state.task.cur_round,
           this.getTagList(this.props),
-          "least_fooled"
+          this.props.taskConfig.fetching_method ?? "least_fooled"
         )
         .then(
           (result) => {


### PR DESCRIPTION
* made a separate api call for 'getting context that failed validation for relabeling'
* only fetch contexts that has 0 success/correct examples and that have failed examples and are not in flight (in validation stage)
* piping the fetching method from taskconfig into the react frontend interface.