### PR TITLE
Remove internet access in docker on AWS

### DIFF
--- a/builder/utils/deployer.py
+++ b/builder/utils/deployer.py
@@ -340,7 +340,7 @@ class ModelDeployer:
             sagemaker_session=self.env["sagemaker_session"],
             predictor_cls=Predictor,
             name=self.unique_name,
-            enable_network_isolation=True
+            enable_network_isolation=True,
         )
 
         torchserve_model.deploy(


### PR DESCRIPTION
Per [AWS documentation](https://sagemaker.readthedocs.io/en/stable/api/inference/model.html) 
```
if True, enables network isolation in the endpoint, isolating the model container. No inbound or outbound network calls can be made to or from the model container.
```
and 
```
If you enable network isolation, the containers can't make any outbound network calls, even to other AWS services such as Amazon S3. Additionally, no AWS credentials are made available to the container runtime environment. In the case of a training job with multiple instances, network inbound and outbound traffic is limited to the peers of each training container. SageMaker still performs download and upload operations against Amazon S3 using your SageMaker execution role in isolation from the training or inference container.
```
This is very strict and include blocking access to S3.

---

Test result: 
- batch transform still runs correctly, however if there's a requests block in the handler (properly handles exception), the job will take significantly longer to run (because AWS retries by default)
- invoking endpoint timeout is 60s 
    - with this requests block in the handler (in `inference` function), the invocation will fail with timeout. But without this requests block, invocation works perfectly 
```
        try:
            r = requests.get("https://api.dynabench.org/tasks")
            r.raise_for_status()
        except requests.exceptions.ConnectionError as ex:
            print(f"No Internet connection! {ex}")
        else:
            print(r.json())
```