### PR TITLE
[fix] Update instance property per AWS documentation

### DIFF
--- a/evaluation/metrics/instance_property.py
+++ b/evaluation/metrics/instance_property.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+# Properties taken from AWS documentation https://aws.amazon.com/sagemaker/pricing/
 
 COMPUTE_CAP_CONSTANT = 10  # for score normalization to compute dynascore
 
@@ -8,7 +9,7 @@ instance_property = {
         "device_type": "cpu",
         "cpu_count": 4,
         "gpu_count": 0,
-        "memory_gb": 32,
+        "memory_gb": 16,
         "compute_cap": COMPUTE_CAP_CONSTANT,
         "aws_metrics": ["examples_per_second", "memory_utilization"],
     }


### PR DESCRIPTION
Was previously lost in AWS documentations and took EC2 property of m5.xlarge which has 32GiB memory. Turns out sagemaker is different and only has 16GiB, although the name is the same :) 


I'll update the db for existing entries. 