### PR TITLE
[fix] Change inference time to total seconds

### DIFF
--- a/evaluation/metrics/metrics.py
+++ b/evaluation/metrics/metrics.py
@@ -106,7 +106,9 @@ def get_examples_per_second(job, dataset):
     n_examples = dataset.get_n_examples()
     eps = (
         n_examples
-        / (job.status["TransformEndTime"] - job.status["TransformStartTime"]).seconds
+        / (
+            job.status["TransformEndTime"] - job.status["TransformStartTime"]
+        ).total_seconds()
     )
     return round(eps, 2)
 


### PR DESCRIPTION
Previous implementation left out the millisecond part, which always underestimated inference time by max 1s and increased compute. This becomes a problem when the total inference time is ~2s, so send the fix here. 