### PR TITLE
Use ml.m5.2xlarge for batch transform jobs by default

### DIFF
--- a/evaluation/metrics/instance_property.py
+++ b/evaluation/metrics/instance_property.py
@@ -15,5 +15,14 @@ instance_property = {
         "memory_gb": 16,
         "compute_cap": COMPUTE_CAP_CONSTANT,
         "aws_metrics": ["examples_per_second", "memory_utilization"],
-    }
+    },
+    "ml.m5.2xlarge": {
+        "instance_type": "ml.m5.2xlarge",
+        "device_type": "cpu",
+        "cpu_count": 8,
+        "gpu_count": 0,
+        "memory_gb": 32,
+        "compute_cap": COMPUTE_CAP_CONSTANT,
+        "aws_metrics": ["examples_per_second", "memory_utilization"],
+    },
 }

--- a/evaluation/metrics/task_config.py
+++ b/evaluation/metrics/task_config.py
@@ -5,7 +5,7 @@ from metrics.instance_property import instance_property
 
 # TODO: long term, move task I/O keys here too
 _default_config = {
-    "instance_config": instance_property["ml.m5.xlarge"],
+    "instance_config": instance_property["ml.m5.2xlarge"],
     "instance_count": 1,
     "eval_metrics": ["accuracy"],
     "perf_metric": "accuracy",


### PR DESCRIPTION
I haven't heard back from AWS regarding my service limit increase request.

For this, we are just requesting a larger machine (32GB) for batch transform jobs. The endpoints will still be using the small machine (16GB) or we will need to redeploy the models. My rationale is that talking to endpoint is not as intensive as batch transform and we don't care about compute in that scenario. I think we should be OK to have smaller machines for endpoints?


---

UPDATE: confirmed with AWS that current limit for batch transform job on ml.m5.2xlarge is 100. 