### PR TITLE
[fix] parsing json in evaluation server output - handle the case where there is bracket in the text

### DIFF
--- a/evaluation/utils/computer.py
+++ b/evaluation/utils/computer.py
@@ -73,11 +73,10 @@ class MetricsComputer:
                 lb = 0
                 while line:
                     line = line.strip()
-                    for c in line:
-                        if c == "{":
-                            lb += 1
-                        elif c == "}":
-                            lb -= 1
+                    if line.startswith("{") or line.endswith("{"):
+                        lb += 1
+                    elif line.startswith("}") or line.endswith("}"):
+                        lb -= 1
                     if lb == 0 and tmp:
                         tmp += line
                         predictions.append(json.loads(tmp))


### PR DESCRIPTION
Previous code failed for an output like 
```
{
    "id": 123,
    "answer": "blabla } well"
}
```
Since it stopped parsing at the first "}" which is part of the output, not the json bracket itself. 