### PR TITLE
added pwc link for each of the 4 visible tasks

### DIFF
--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -584,12 +584,7 @@ class TaskPage extends React.Component {
 
   render() {
     const pwc_logo = (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        height="30"
-        width="30"
-        viewBox="0 0 512 512"
-      >
+      <svg height="30" width="30" viewBox="0 0 512 512">
         <path
           fill="#21cbce"
           d="M88 128h48v256H88zm144 0h48v256h-48zm-72 16h48v224h-48zm144 0h48v224h-48zm72-16h48v256h-48z"


### PR DESCRIPTION
I could also make the logo grey if you want, but I think that making it the actual PwC colors help it stand out as the PwC logo.
<img width="1792" alt="Screen Shot 2021-05-04 at 4 02 56 PM" src="https://user-images.githubusercontent.com/20826878/117080461-b85b8200-acf2-11eb-863b-706aa1ff7fe4.png">
