### PR TITLE
[fix] make sure the object stays in session

### DIFF
--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -101,11 +101,14 @@ def get_random_example(credentials, tid, rid):
         tags=tags,
         context_tags=context_tags,
     )
-
     if not example:
         bottle.abort(500, f"No examples available ({round.id})")
 
-    example = example[0].to_dict()
+    example = example[0]
+    if example not in em.dbs:
+        example = em.dbs.merge(example)
+
+    example = example.to_dict()
     return util.json_encode(example)
 
 


### PR DESCRIPTION
previously the objects can get detached in a session; calling merge on it ensures that the object stays in session.

This is the last diff in a series of diff that addresses validation issues, they are:
1. #469, to include more examples whose context only has failed validations and no successful ones
2. #474, to restrict the context, examples fetched to match tags and context_tags
3. #475, to clean up and offer speed up and remove duplicate logic
4. #478, to use "having" in the filter clause on the subqueries rather than "filter".
5. this current one, move the object fetched into the session to avoid error like this:

```
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <Example at 0x7f77a3a536d0> is not bound to a Session; lazy load operation of attribute 'context' cannot proceed (Background on this error at: http://sqlalche.me/e/13/bhk3)
```