### PR TITLE
QA Answer Overrides

### DIFF
--- a/frontends/web/src/containers/CreateInterface.js
+++ b/frontends/web/src/containers/CreateInterface.js
@@ -599,7 +599,7 @@ class ResponseInfo extends React.Component {
           <strong>{this.props.obj.modelPredStr}</strong>.
         </span>
       );
-    } else {     
+    } else {
       if (this.state.fooled === "no") {
         classNames += " response-warning";
         submissionResults = (
@@ -648,7 +648,9 @@ class ResponseInfo extends React.Component {
                     type="text"
                     style={{ width: 100 + "%", marginBottom: "1px" }}
                     placeholder={
-                      "Explain why " + this.props.obj.targetText + " is the correct answer"
+                      "Explain why " +
+                      this.props.obj.targetText +
+                      " is the correct answer"
                     }
                     data-index={this.props.index}
                     data-type="example"
@@ -692,7 +694,9 @@ class ResponseInfo extends React.Component {
                     type="text"
                     style={{ width: 100 + "%", marginBottom: "1px" }}
                     placeholder={
-                      "Explain why " + this.props.obj.targetText + " is the correct answer"
+                      "Explain why " +
+                      this.props.obj.targetText +
+                      " is the correct answer"
                     }
                     data-index={this.props.index}
                     data-type="example"
@@ -1148,7 +1152,10 @@ class CreateInterface extends React.Component {
                       modelPredStr: modelPredStr,
                       fooled: modelFooled,
                       text: this.state.hypothesis,
-                      targetText: this.state.task.type == "clf" ? this.state.task.targets[this.state.target] : this.state.target,
+                      targetText:
+                        this.state.task.type == "clf"
+                          ? this.state.task.targets[this.state.target]
+                          : this.state.target,
                       url: this.state.randomTargetModel,
                       retracted: false,
                       prob: probList,


### PR DESCRIPTION
Fix for bug spotted by Tristan where if you ask multiple answers in QA, the answers to the previously asked questions also get updated to the current answer. This does not appear to affect the stored examples but can be confusing for users.

@douwekiela can you please double check that it doesn't affect anything for VQA as I'm not familiar with that interface?