### PR TITLE
[fix][robustness] remove subpopulation methods from textflint

### DIFF
--- a/evaluation/scripts/textflint_utils/configs/hs_config.json
+++ b/evaluation/scripts/textflint_utils/configs/hs_config.json
@@ -9,5 +9,6 @@
     "SpellingError",
     "Typos",
     "WordCase"
-  ]
+  ],
+  "sub_methods": []
 }

--- a/evaluation/scripts/textflint_utils/configs/nli_config.json
+++ b/evaluation/scripts/textflint_utils/configs/nli_config.json
@@ -9,5 +9,6 @@
     "SpellingError",
     "Typos",
     "WordCase"
-  ]
+  ],
+  "sub_methods": []
 }

--- a/evaluation/scripts/textflint_utils/configs/qa_config.json
+++ b/evaluation/scripts/textflint_utils/configs/qa_config.json
@@ -8,5 +8,6 @@
     "Punctuation",
     "SpellingError",
     "Typos"
-  ]
+  ],
+  "sub_methods": []
 }

--- a/evaluation/scripts/textflint_utils/configs/sentiment_config.json
+++ b/evaluation/scripts/textflint_utils/configs/sentiment_config.json
@@ -9,5 +9,6 @@
     "SpellingError",
     "Typos",
     "WordCase"
-  ]
+  ],
+  "sub_methods": []
 }


### PR DESCRIPTION
Set "sub_methods" to empty set to avoid subpopulation transformations from textflint