### PR TITLE
Make Flores public

### DIFF
--- a/api/migrations/20210521_01_xxxx-open_flores.py
+++ b/api/migrations/20210521_01_xxxx-open_flores.py
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
+"""
+Hide Flores task until June 4th, 2021.
+"""
+from datetime import datetime, timezone
+
+from yoyo import step
+
+
+__depends__ = {
+    "20210503_01_xxxx-add-flores-task",
+    "20210520_01_tOL8u-add-task-submitable-status",
+}
+
+
+tasks = "('flores_small1', 'flores_small2', 'flores_full')"
+
+step(
+    f"""
+    UPDATE tasks SET hidden = true, submitable = true
+    WHERE task_code in {tasks}
+    """,
+    f"""
+    UPDATE tasks SET hidden = false, submitable = false
+    WHERE task_code in {tasks}
+    """,
+)


### PR DESCRIPTION
This PR is based on @mazhiyi PR #539 , look only at the last commit: edc40c4d.

Is it possible to have a hidden status that depends on the date ? 

Here I've made Flores both hidden and submittable. Is that fine by you ?
We would like to submit the baselines before the public launch.