### PR TITLE
fixed incorrect use of vmer

### DIFF
--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -251,7 +251,7 @@ const OverallTaskStats = (props) => {
         </tr>
         {props.task.round && (
           <tr>
-            <td>Correct/Validated (Validated Model Error rate)</td>
+            <td>Correct/Validated</td>
             <td>
               {props.task.round?.correct_validations}/
               {props.task.round?.total_validations} (


### PR DESCRIPTION
I noticed that correct/validated was being reported as VMER on the task page. Elsewhere, we define VMER as (verified fooled)/(total collected).