### PR TITLE
Corrected display of values on grid axis

### DIFF
--- a/frontends/web/src/components/FloresComponents/FloresGrid.js
+++ b/frontends/web/src/components/FloresComponents/FloresGrid.js
@@ -197,7 +197,7 @@ const FloresGrid = ({ model }) => {
 
         return (
           `${source.LANGUAGE ?? langSourceCode} (${langSourceCode}) --> ` +
-          `${target.LANGUAGE ?? langTargetCode} (${langTargetCode})</br>` +
+          `${target.LANGUAGE ?? langTargetCode} (${langTargetCode}) </br>` +
           "<b>BLEU Score: </b>" +
           valuePoint
         );


### PR DESCRIPTION
Corrected display of BLEU scores on grid from source to target language. 
Source languages to target languages scores were incorrect displaying on Y axis.

https://user-images.githubusercontent.com/84393628/121187217-d5292f00-c835-11eb-915b-d7229062dbdf.mov

Corrected display

https://user-images.githubusercontent.com/84393628/121187270-e1ad8780-c835-11eb-8e80-033889bab12e.mov

![Api response Score](https://user-images.githubusercontent.com/84393628/121214272-f0ebff80-c84c-11eb-9de7-72ce9b10952a.png)
