### PR TITLE
Added fallback UI on flores model page

### DIFF
--- a/frontends/web/src/components/FloresComponents/FloresGrid.js
+++ b/frontends/web/src/components/FloresComponents/FloresGrid.js
@@ -10,6 +10,7 @@ import highchartsHeatmap from "highcharts/modules/heatmap";
 import HighchartsReact from "highcharts-react-official";
 import highchartsBoost from "highcharts/modules/boost";
 import highchartsCluster from "highcharts/modules/marker-clusters";
+import { Alert } from "react-bootstrap";
 
 import FloresLanguages from "./FloresLanguages";
 import "./FloresGrid.css";
@@ -80,7 +81,7 @@ const FloresGrid = ({ model }) => {
 
   useEffect(() => {
     const perf_by_tag =
-      model.leaderboard_scores[0].metadata_json &&
+      model.leaderboard_scores[0] &&
       JSON.parse(model.leaderboard_scores[0].metadata_json).hasOwnProperty(
         "perf_by_tag"
       )
@@ -223,7 +224,13 @@ const FloresGrid = ({ model }) => {
   return (
     <div className="scroll-wrapper">
       <div className="mr-auto ml-auto my-4 pb-1">
-        <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+        {data.length > 0 ? (
+          <HighchartsReact highcharts={Highcharts} options={chartOptions} />
+        ) : (
+          <Alert variant={"info"}>
+            No data available, the model is still evaluating.
+          </Alert>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
### When user uploads a model but model isn't done evaluating.

![scores_notfound copy](https://user-images.githubusercontent.com/84393628/121727094-71169d00-cab9-11eb-9ecf-08d8f1a9030e.jpg)

Fixed hook and added UI fallback.

<img width="1638" alt="Screen Shot 2021-06-11 at 1 07 29 PM" src="https://user-images.githubusercontent.com/84393628/121727362-ceaae980-cab9-11eb-816a-f115862e785f.png">


