### PR TITLE
fixed admin setting loading bug

### DIFF
--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -395,7 +395,6 @@ class TaskPage extends React.Component {
             },
             function () {
               this.refreshData();
-              this.getSavedTaskSettings();
             }
           );
         },
@@ -442,16 +441,23 @@ class TaskPage extends React.Component {
   getSavedTaskSettings() {
     if (this.state.task.settings_json) {
       const settings_json = JSON.parse(this.state.task.settings_json);
-      if (settings_json.hasOwnProperty("validate_non_fooling")) {
-        this.setState({
-          validateNonFooling: settings_json["validate_non_fooling"],
-        });
-      }
-      if (settings_json.hasOwnProperty("num_matching_validations")) {
-        this.setState({
-          numMatchingValidations: settings_json["num_matching_validations"],
-        });
-      }
+      this.setState({
+        validateNonFooling: settings_json.hasOwnProperty("validate_non_fooling")
+          ? settings_json["validate_non_fooling"]
+          : false,
+      });
+      this.setState({
+        numMatchingValidations: settings_json.hasOwnProperty(
+          "num_matching_validations"
+        )
+          ? settings_json["num_matching_validations"]
+          : 3,
+      });
+    } else {
+      this.setState({
+        validateNonFooling: false,
+        numMatchingValidations: 3,
+      });
     }
   }
 
@@ -471,6 +477,7 @@ class TaskPage extends React.Component {
       },
       () => {
         this.fetchOverallUserLeaderboard(this.state.userLeaderBoardPage);
+        this.getSavedTaskSettings();
         if (this.props.location.hash === "#overall") this.fetchTrend();
       }
     );


### PR DESCRIPTION
I believe that this was only a problem for admins, or people who are task owners of more than one task. The problem was that, if you go from one task page to another, the settings in the task owner console wouldn't refresh without manually refreshing your browser.