### PR TITLE
Export model scores as CSV

### DIFF
--- a/frontends/web/src/containers/ModelPage.js
+++ b/frontends/web/src/containers/ModelPage.js
@@ -251,11 +251,8 @@ class ModelPage extends React.Component {
   };
 
   downloadCsv = () => {
-    const {
-      leaderboard_scores,
-      non_leaderboard_scores,
-      name,
-    } = this.state.model;
+    const { leaderboard_scores, non_leaderboard_scores, name } =
+      this.state.model;
     const { task } = this.state;
     const taskName = task.name;
 


### PR DESCRIPTION
* Added button to export scores for a model as CSV from the Model Overview Page.

* The CSV is exported in the following format -

Dataset Name	Accuracy

Leaderboard Datasets
dataset-1	     accuracy-1
dataset-2     accuracy-2
.
.

Non-leaderboard Datasets
dataset-1      accuracy-1
dataset-2     accuracy-2
.
.
