### PR TITLE
Fixes issue #593

### DIFF
--- a/api/common/auth.py
+++ b/api/common/auth.py
@@ -156,9 +156,6 @@ def get_expired_token_payload():
         token,
         app.config["jwtsecret"],
         algorithms=[app.config["jwtalgo"]],
-        options={
-            "verify_signature": False,
-            "verify_exp": False,
-        }
+        options={"verify_signature": False, "verify_exp": False},
     )
     return payload


### PR DESCRIPTION
Fixes the issue due to which the refresh token endpoint (/authenticate/refresh) fails when JWT is already expired. The bug can be reproduced by following the steps mentioned in the linked [issue](https://github.com/facebookresearch/dynabench/issues/593).

This PR makes sure that the expiry of the jwt token is not verified when we are trying to refresh a token. Following is the test plan to verify the correctness of this PR - 
1. In the config.py on your backend, reduce the value of jwtexp field to a small number, say a few seconds.
2. Run the frontend and the backend, and login to your account.
3. Wait for sufficient amount of time (equal to what you set in step 1) so that the JWT token expires.
4. Trigger the /authenticate/refresh endpoint from the frontend. For example, click the user profile icon from the navigation bar on the top of the screen.
5. As per the screenshot attached below, no error message will be thrown and the endpoint will execute successfully.
6. Refreshing the webpage will not log the user out of the application.

<img width="1303" alt="Screenshot 2021-06-25 at 19 22 11" src="https://user-images.githubusercontent.com/42480592/123469218-a7d8d100-d5ea-11eb-9512-d0b91ae2affd.png">
