### PR TITLE
added ability to get top scores by tag

### DIFF
--- a/api/controllers/tasks.py
+++ b/api/controllers/tasks.py
@@ -249,13 +249,16 @@ def construct_user_board_response_json(query_result, total_count=0):
 def get_top_leaderboard_tags(tid):
     offset = 0
     limit = 5
+    specific_tag = None
     query_dict = parse_qs(bottle.request.query_string)
     if "offset" in query_dict:
         offset = int(query_dict["offset"][0])
     if "limit" in query_dict:
         limit = int(query_dict["limit"][0])
+    if "specific_tag" in query_dict:
+        specific_tag = query_dict["specific_tag"][0]
     sm = ScoreModel()
-    return sm.getLeaderboardTopPerformingTags(tid, limit, offset)
+    return sm.getLeaderboardTopPerformingTags(tid, limit, offset, specific_tag)
 
 
 @bottle.get("/tasks/<tid:int>/models/dynaboard")

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -224,9 +224,11 @@ export default class ApiService {
     });
   }
 
-  getLeaderboardTopPerformingTags(taskId, limit, offset) {
+  getLeaderboardTopPerformingTags(taskId, limit, offset, specific_tag = null) {
     const pageQuery = `limit=${limit || 10}&offset=${offset || 0}`;
-    const url = `/models/topleaderboardtags?${pageQuery}`;
+    const specificTagQuery =
+      specific_tag === null ? `` : `&specific_tag=${specific_tag}`;
+    const url = `/models/topleaderboardtags?${pageQuery}${specificTagQuery}`;
     return this.fetch(`${this.domain}/tasks/${taskId}${url}`, {
       method: "GET",
     });


### PR DESCRIPTION
Adds an API call to unblock #592. Allows you to request the top scoring tags for each task. Returns the results separately for each leaderboard dataset. It allows for paging, because it allows you to include limit and offset, and it returns the total count. It also allows for filtering by specific tag. In this case, only one result is returned. 

Results are sorted from highest to lowest and returned in this format:

```
{'flores101-full-devtest': {'count': 10100, 'data': [{'tag': 'eng-mlt', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 49.74}}, {'tag': 'mlt-eng', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 49.19}}, {'tag': 'afr-eng', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 47.31}}, {'tag': 'eng-por', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 44.84}}, {'tag': 'eng-fra', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 41.99}}, {'tag': 'por-eng', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 41.53}}, {'tag': 'eng-dan', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 41.12}}, {'tag': 'dan-eng', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 41.08}}, {'tag': 'eng-swe', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 40.23}}, {'tag': 'por-fra', 'top_perf_info': {'model_id': 88, 'model_name': 'M2M-124 615M', 'uid': 75, 'username': 'anon_user', 'perf': 40.17}}]}}
```