### PR TITLE
Make TaskLeaderboardCard.js more reusable

### DIFF
--- a/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCard.js
@@ -9,7 +9,7 @@ import {
   Modal,
 } from "react-bootstrap";
 import UserContext from "../../containers/UserContext";
-import TaskLeaderboardTable from "./TaskLeaderboardTable";
+import TaskModelLeaderboardTable from "./TaskModelLeaderboardTable";
 import ForkModal from "./ForkModal";
 
 const SortDirection = {
@@ -34,7 +34,7 @@ const SortDirection = {
  * @param {string} props.history navigation API
  * @param {string} props.location navigation location
  */
-const TaskLeaderboardCard = (props) => {
+const TaskModelLeaderboardCard = (props) => {
   const task = props.task;
 
   const [data, setData] = useState([]);
@@ -340,7 +340,7 @@ const TaskLeaderboardCard = (props) => {
         </div>
       </Card.Header>
       <Card.Body className="p-0 leaderboard-container">
-        <TaskLeaderboardTable
+        <TaskModelLeaderboardTable
           models={data}
           enableWeights={enableWeights}
           metrics={metrics}
@@ -376,4 +376,4 @@ const TaskLeaderboardCard = (props) => {
     </Card>
   );
 };
-export default TaskLeaderboardCard;
+export default TaskModelLeaderboardCard;

--- a/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCardWrapper.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCardWrapper.js
@@ -1,18 +1,18 @@
 import React from "react";
-import TaskLeaderboardCard from "./TaskLeaderboardCard";
+import TaskModelLeaderboardCard from "./TaskModelLeaderboardCard";
 
 /**
  *
- * This is a wrapper around TaskLeaderboardCard.js which allows to extract out the logic for initializing weights
+ * This is a wrapper around TaskModelLeaderboardCard.js which allows to extract out the logic for initializing weights
  * and fetching leaderboard data. A custom task leaderboard can be created simply by passing in custom functions for
  * initializing weights and fetching data.
  *
  * @param getInitialWeights Function that defines how weights for metrics and datasets are to be initialized
  * @param fetchLeaderboardData Function that defines how the leaderboard data is to be fetched
- * @returns {function(*)} A functional component that uses the custom function passed to TaskLeaderboardCardWrapper
- * and renders the TaskLeaderboardCard.
+ * @returns {function(*)} A functional component that uses the custom function passed to TaskModelLeaderboardCardWrapper
+ * and renders the TaskModelLeaderboardCard.
  */
-const TaskLeaderboardCardWrapper = (
+const TaskModelLeaderboardCardWrapper = (
   getInitialWeights,
   fetchLeaderboardData
 ) => {
@@ -23,7 +23,7 @@ const TaskLeaderboardCardWrapper = (
     };
 
     return (
-      <TaskLeaderboardCard
+      <TaskModelLeaderboardCard
         {...props}
         getInitialWeights={(task, api, setWeightsCallback) => {
           getInitialWeights(task, api, setWeightsCallback, extraData);
@@ -122,7 +122,7 @@ const getOrderedWeightObjects = (
   return { orderedMetricWeights, orderedDatasetWeights };
 };
 
-export const DefaultTaskLeaderboard = TaskLeaderboardCardWrapper(
+export const TaskModelDefaultLeaderboard = TaskModelLeaderboardCardWrapper(
   (task, api, setWeightsCallback) => {
     const metricIdToDataObj = {};
     const datasetIdToDataObj = {};
@@ -135,7 +135,7 @@ export const DefaultTaskLeaderboard = TaskLeaderboardCardWrapper(
   loadDefaultData
 );
 
-export const ForkedTaskLeaderboard = TaskLeaderboardCardWrapper(
+export const TaskModelForkLeaderboard = TaskModelLeaderboardCardWrapper(
   (task, api, setWeightsCallback, extraData) => {
     const metricIdToDataObj = {};
     const datasetIdToDataObj = {};

--- a/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardTable.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardTable.js
@@ -177,7 +177,7 @@ const SortContainer = ({
  * @param {*} datasetWeights Datasets metadata use for labels and weights.
  *
  */
-const TaskLeaderboardRow = ({ model, metrics, datasetWeights }) => {
+const TaskModelLeaderboardRow = ({ model, metrics, datasetWeights }) => {
   const [expanded, setExpanded] = useState(false);
 
   const dynascore = parseFloat(model.dynascore).toFixed(2);
@@ -364,7 +364,7 @@ const MetricWeightTableHeader = ({
  *
  * @param {Array} props.models the models to show
  */
-const TaskLeaderboardTable = ({
+const TaskModelLeaderboardTable = ({
   models,
   enableWeights,
   metrics,
@@ -477,7 +477,7 @@ const TaskLeaderboardTable = ({
       </thead>
       <tbody>
         {models?.map((model) => (
-          <TaskLeaderboardRow
+          <TaskModelLeaderboardRow
             model={model}
             metrics={metrics}
             key={`model-${model.model_id}`}
@@ -489,4 +489,4 @@ const TaskLeaderboardTable = ({
   );
 };
 
-export default TaskLeaderboardTable;
+export default TaskModelLeaderboardTable;

--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -33,9 +33,9 @@ import Moment from "react-moment";
 import DragAndDrop from "../components/DragAndDrop/DragAndDrop";
 import { OverlayProvider, Annotation, OverlayContext } from "./Overlay";
 import {
-  DefaultTaskLeaderboard,
-  ForkedTaskLeaderboard,
-} from "../components/TaskLeaderboard/TaskLeaderboardCardWrapper";
+  TaskModelDefaultLeaderboard,
+  TaskModelForkLeaderboard,
+} from "../components/TaskLeaderboard/TaskModelLeaderboardCardWrapper";
 
 const chartSizes = {
   xs: { fontSize: 10 },
@@ -923,13 +923,13 @@ class TaskPage extends React.Component {
                   tooltip="This shows how models have performed on this task - the top-performing models are the ones we’ll use for the next round"
                 >
                   {this.props.match.params.leaderboardName ? (
-                    <ForkedTaskLeaderboard
+                    <TaskModelForkLeaderboard
                       {...this.props}
                       task={this.state.task}
                       taskId={this.state.taskId}
                     />
                   ) : (
-                    <DefaultTaskLeaderboard
+                    <TaskModelDefaultLeaderboard
                       {...this.props}
                       task={this.state.task}
                       taskId={this.state.taskId}


### PR DESCRIPTION
* Added some props to enable/disable sorting, adjusting weights, forking, snapshotting
* Logic to initialize metric/datasets weights and fetching leaderboard data extracted to parent page

With this PR, we attempt to make the TaskLeaderboardCard more reusable for future work such as Snapshots (https://github.com/facebookresearch/dynabench/issues/584) and Leaderboard widget (https://github.com/facebookresearch/dynabench/issues/613).

This PR will not change any behaviour on the dynabench website. To verify that the leaderboard still opens correctly on the default task page - 
1. Visit the deployment of the master branch [here](http://anmol.dynabench.org:3000/tasks/1) and take note of the default weights assigned to metrics and datasets.
2. Visit the test website [here](http://anmol.dynabench.org:3002/tasks/1) and verify that the weights assigned to metrics and datasets are the same as what we have on the prod website.

<img width="897" alt="Screenshot 2021-07-20 at 12 57 43" src="https://user-images.githubusercontent.com/42480592/126319870-86283a1e-1d10-45f2-ab30-5e2bf904bfb6.png">


To verify that leaderboard forking still works correctly - 
1. Visit a fork on the deployment of the master branch [here](http://anmol.dynabench.org:3000/tasks/1/leaderboard_configuration/test-fork). Notice the weights assigned to metrics and datasets. In particular, the weight of accuracy metric is set to 2 instead of default value of 4. The weight of snli-test dataset is set to 0 instead of default value of 5.
2. Visit the same fork on the deployment of this branch [here](http://anmol.dynabench.org:3002/tasks/1/leaderboard_configuration/test-fork). Verify that the weights assigned to metrics and datasets are same as what you saw in step 1 (accuracy weight = 2 and snli-test weight = 0).

<img width="898" alt="Screenshot 2021-07-20 at 12 57 09" src="https://user-images.githubusercontent.com/42480592/126319822-734ef3ab-47f0-43fe-a09b-ce55e3d8eae6.png">
