### PR TITLE
Feat/detached models

### DIFF
--- a/api/migrations/20210726_01_OFiwm-add-detached-model-status.py
+++ b/api/migrations/20210726_01_OFiwm-add-detached-model-status.py
@@ -1,10 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
 """
 Add detached model status
 """
 
 from yoyo import step
 
-__depends__ = {'20210630_01_s8Xod-update-model-url-to-authorized-endpoint', '20210706_01_a9a26-fix-flores-description', '20210714_01_Fbdh6-add_flores_unpublished_dynaboard_setting'}
+
+__depends__ = {
+    "20210630_01_s8Xod-update-model-url-to-authorized-endpoint",
+    "20210706_01_a9a26-fix-flores-description",
+    "20210714_01_Fbdh6-add_flores_unpublished_dynaboard_setting",
+}
 
 steps = [
     step(


### PR DESCRIPTION
To make a leaderboard with detached models that only considers the perf metric, you can now do this:

```
<TaskModelDefaultLeaderboard
                      {...this.props}
                      task={taskForPerfOnlyLeaderboard}
                      taskId={this.state.taskId}
                      specificDeploymentStatus={"detached"}
                    />
```

Where taskForPerfOnlyLeaderboard is defined as:

```
const taskForPerfOnlyLeaderboard = JSON.parse(
      JSON.stringify(this.state.task)
    );
    taskForPerfOnlyLeaderboard.ordered_metrics = taskForPerfOnlyLeaderboard.ordered_metrics?.filter(
      (metric) =>
        metric.field_name === taskForPerfOnlyLeaderboard.perf_metric_field_name
    );
```