### PR TITLE
Update model scores CSV to use proper format

### DIFF
--- a/frontends/web/src/containers/ModelPage.js
+++ b/frontends/web/src/containers/ModelPage.js
@@ -256,11 +256,7 @@ class ModelPage extends React.Component {
     const rows = [];
     rows.push(["dataset-name", "dataset-type", task.perf_metric_field_name]);
     this.processScoresArray(rows, leaderboard_scores, "leaderboard");
-    this.processScoresArray(
-      rows,
-      non_leaderboard_scores,
-      "non-leaderboard"
-    );
+    this.processScoresArray(rows, non_leaderboard_scores, "non-leaderboard");
 
     let csvContent = "data:text/csv;charset=utf-8,";
 


### PR DESCRIPTION
As per [this issue](https://github.com/facebookresearch/dynabench/issues/605), we would like to change the csv format for exporting model eval scores.

To verify that the change was made successfully - 
1. Visit the test website [here](http://anmol.dynabench.org:3000/models/108) and click on the Export button.
2. Click on the CSV option to export the scores in a .csv file. Below is a screenshot of what the new CSV looks like - 
<img width="369" alt="Screenshot 2021-07-27 at 10 23 17" src="https://user-images.githubusercontent.com/42480592/127132668-df9f0f0a-a8a9-438f-8ac2-3b7ef0f2049c.png">

I have also attached two sample CSV files generated with this change -
[sample-csv-files.zip](https://github.com/facebookresearch/dynabench/files/6884416/sample-csv-files.zip)
