### PR TITLE
remove python3.9 idiom

### DIFF
--- a/evaluation/metrics/task_config.py
+++ b/evaluation/metrics/task_config.py
@@ -56,7 +56,7 @@ tasks_config = {
     "hs": _gen_config(),
     "sentiment": _gen_config(),
     "qa": _gen_config(_custom_config["qa"]),
-    "flores_full": _gen_config(_custom_config["flores"]) | {"instance_count": 16},
+    "flores_full": {**_gen_config(_custom_config["flores"]), "instance_count": 16},
     "flores_small1": _gen_config(_custom_config["flores"]),
     "flores_small2": _gen_config(_custom_config["flores"]),
 }


### PR DESCRIPTION
Could we add some 3.7 specific linting ? Mypy can do that maybe also pylint ?