### PR TITLE
throttle timestamping of Job so they are unique

### DIFF
--- a/evaluation/utils/helpers.py
+++ b/evaluation/utils/helpers.py
@@ -66,17 +66,6 @@ def send_takedown_model_request(model_id, config, s3_uri=None, logger=None):
     return True
 
 
-def generate_job_name(endpoint_name, dataset_name, perturb_prefix=None):
-    # :63 is AWS requirement; timestamp has fewer digits than uuid and should be
-    # sufficient for dedup purpose
-    perturb_prefix = f"{perturb_prefix}-" if perturb_prefix else ""
-    timestamp = str(int(time.time()))
-    jobname_prefix = f"{endpoint_name}-{perturb_prefix}{dataset_name}"[
-        : 62 - len(timestamp)
-    ]
-    return f"{jobname_prefix}-{timestamp}"
-
-
 def round_end_dt(dt, delta=60, offset=1):
     delta = timedelta(seconds=delta)
     dt_naive = dt.replace(tzinfo=None)


### PR DESCRIPTION
This is an answer to #633.

This PR doesn't change the naming scheme.
It can be combined with #634 to have a different naming sheme,
but I think the throttling is still a good idea to ensure unique job names despite truncation.

The main idea is to throttle  timestamping of Job so the timestamps are unique.
It delay the timestamping just before submission to not slow down the enqueueing.
This is important, since SQS expect us to handle the message in <30 seconds.

But it also means that the job in the scheduler queue will have a temporary job name.
The temporary job name have their timestamp replaced by "???". 
This temporary job name will only be used for displaying the status of the job.
The first time the scheduler tries to submit the job, the job will get a unique timestamp.