### PR TITLE
Prepare forks and snapshots for ldbd.ly redirection

### DIFF
--- a/api/controllers/tasks.py
+++ b/api/controllers/tasks.py
@@ -522,7 +522,11 @@ def create_leaderboard_configuration(credentials, tid):
         bottle.abort(409, "A fork with the same name already exists for this task.")
 
     leaderboard_configuration = lcm.create(
-        tid, name, credentials["id"], data["configuration_json"]
+        tid,
+        name,
+        credentials["id"],
+        configuration_json=data["configuration_json"],
+        desc=data.get("description", None),
     )
     return util.json_encode(leaderboard_configuration)
 

--- a/api/migrations/20210808_01_OtRTz-add-desc-to-leaderboard-fork.py
+++ b/api/migrations/20210808_01_OtRTz-add-desc-to-leaderboard-fork.py
@@ -1,0 +1,18 @@
+"""
+add-desc-to-leaderboard-fork
+"""
+
+from yoyo import step
+
+
+__depends__ = {
+    "20210723_01_PTI5B-add-leaderboard-snapshots-table",
+    "20210730_01_02Na6-change-example-metadata-json-type-to-mediumtext",
+}
+
+steps = [
+    step(
+        "ALTER TABLE leaderboard_configurations ADD COLUMN `desc` TEXT DEFAULT NULL",
+        "ALTER TABLE leaderboard_configurations DROP COLUMN `desc`",
+    )
+]

--- a/api/models/leaderboard_configuration.py
+++ b/api/models/leaderboard_configuration.py
@@ -13,6 +13,7 @@ class LeaderboardConfiguration(Base):
     name = db.Column(db.String(length=255), primary_key=True)
     uid = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
 
+    desc = db.Column(db.Text)
     create_datetime = db.Column(db.DateTime)
     configuration_json = db.Column(db.Text, nullable=False)
 
@@ -30,13 +31,13 @@ class LeaderboardConfigurationModel(BaseModel):
     def __init__(self):
         super().__init__(LeaderboardConfiguration)
 
-    def create(self, tid, name, user_id, configuration_json):
+    def create(self, tid, name, user_id, **kwargs):
         lc = LeaderboardConfiguration(
             tid=tid,
             name=name,
             uid=user_id,
             create_datetime=datetime.datetime.utcnow(),
-            configuration_json=configuration_json,
+            **kwargs,
         )
         self.dbs.add(lc)
         self.dbs.commit()

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -532,12 +532,13 @@ export default class ApiService {
     });
   }
 
-  createLeaderboardConfiguration(tid, name, configuration_json) {
+  createLeaderboardConfiguration(tid, name, configuration_json, description) {
     return this.fetch(`${this.domain}/tasks/${tid}/leaderboard_configuration`, {
       method: "PUT",
       body: JSON.stringify({
         name: name,
         configuration_json: configuration_json,
+        description: description,
       }),
     });
   }

--- a/frontends/web/src/components/TaskLeaderboard/SnapshotModal.js
+++ b/frontends/web/src/components/TaskLeaderboard/SnapshotModal.js
@@ -61,7 +61,7 @@ const SnapshotModal = (props) => {
       .then(
         (result) => {
           const snapshotUrl = new URL(window.location.href);
-          snapshotUrl.pathname = `/tasks/${taskCode}/s/${result.id}`;
+          snapshotUrl.pathname = `/tasks/${taskCode}/${result.id}`;
           setSnapshotUrl(snapshotUrl.toString());
           setSnapshotCreatedSuccessfully(true);
         },

--- a/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCard.js
@@ -7,6 +7,7 @@ import {
   Tooltip,
   OverlayTrigger,
   Modal,
+  Popover,
 } from "react-bootstrap";
 import UserContext from "../../containers/UserContext";
 import TaskModelLeaderboardTable from "./TaskModelLeaderboardTable";
@@ -57,6 +58,7 @@ const TaskModelLeaderboardCard = (props) => {
     props.getInitialWeights(task, context.api, (result) => {
       setMetrics(result.orderedMetricWeights);
       setDatasetWeights(result.orderedDatasetWeights);
+      setDescription(result.description);
     });
   }, [task]);
 
@@ -71,6 +73,7 @@ const TaskModelLeaderboardCard = (props) => {
   const [total, setTotal] = useState(0);
   const [showForkModal, setShowForkModal] = useState(false);
   const [showSnapshotModal, setShowSnapshotModal] = useState(false);
+  const [description, setDescription] = useState(null);
 
   // Runs on taskID update only, i.e. task change, initialize page to 0.
   useEffect(() => {
@@ -186,6 +189,25 @@ const TaskModelLeaderboardCard = (props) => {
         <h2 className="text-uppercase m-0 text-reset">
           {props.title || "Model Leaderboard"}
         </h2>
+        {description && description.length !== 0 && (
+          <OverlayTrigger
+            placement={"right"}
+            delay={{ show: 250, hide: 400 }}
+            overlay={
+              <Popover>
+                {<Popover.Content>{description}</Popover.Content>}
+              </Popover>
+            }
+          >
+            <div className="d-inline-block">
+              <i
+                style={{ lineHeight: "inherit" }}
+                className="fa fa-info-circle ml-1 align-middle"
+                aria-hidden="true"
+              />
+            </div>
+          </OverlayTrigger>
+        )}
         <div className="d-flex justify-content-end flex-fill">
           <ForkModal
             metricWeights={metrics}

--- a/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCardWrapper.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCardWrapper.js
@@ -166,9 +166,14 @@ export const TaskModelForkLeaderboard = taskModelLeaderboardCardWrapper(
             datasetIdToDataObj[d.id].weight = d.weight;
           }
         });
-        setWeightsCallback(
-          getOrderedWeightObjects(metricIdToDataObj, datasetIdToDataObj, task)
-        );
+        setWeightsCallback({
+          ...getOrderedWeightObjects(
+            metricIdToDataObj,
+            datasetIdToDataObj,
+            task
+          ),
+          description: result.desc,
+        });
       },
       (error) => {
         console.log(error);

--- a/frontends/web/src/containers/App.js
+++ b/frontends/web/src/containers/App.js
@@ -283,12 +283,12 @@ class App extends React.Component {
                   component={TaskPage}
                 />
                 <Route
-                  path="/tasks/:taskCode/f/:leaderboardName"
-                  component={TaskPage}
+                  path="/tasks/:taskCode/:snapshotId(\d+)"
+                  component={TaskModelLeaderboardSnapshotPage}
                 />
                 <Route
-                  path="/tasks/:taskCode/s/:snapshotId"
-                  component={TaskModelLeaderboardSnapshotPage}
+                  path="/tasks/:taskCode/:leaderboardName"
+                  component={TaskPage}
                 />
                 <Route path="/tasks/:taskCode" component={TaskPage} />
                 <Route

--- a/frontends/web/src/containers/TaskPage.js
+++ b/frontends/web/src/containers/TaskPage.js
@@ -457,6 +457,7 @@ class TaskPage extends React.Component {
                       {...this.props}
                       task={this.state.task}
                       taskCode={this.state.taskCode}
+                      title={"Model Leaderboard (Fork)"}
                     />
                   ) : (
                     <TaskModelDefaultLeaderboard
@@ -472,7 +473,7 @@ class TaskPage extends React.Component {
           <Row>
             <Col xs={12} md={6}>
               <UserLeaderboardCard
-                taskId={this.state.taskId}
+                taskId={this.state.task.id}
                 round={this.state.task.round}
                 cur_round={this.state.task.cur_round}
               />


### PR DESCRIPTION
* Add description to forks
* Remove `/f/` and `/s/` from fork and snapshot urls

Once this is merged into master and deployed to prod, we will be able to use `ldbd.ly/<task_code>/<forkName-or-snapshotId>` to open fork or snapshot pages.

In order to verify that description is working for forks -
1. Visit the test deployment of this branch [here](http://anmol.dynabench.org:3004/tasks/nli).
2. Click on the fork button as highlighted in the screenshot below.
<img width="1792" alt="Screenshot 2021-08-09 at 23 48 42" src="https://user-images.githubusercontent.com/42480592/128783884-d54d311a-4e32-4e06-80f1-3dd0876528b3.png">

3. Enter a name and description for the fork.
<img width="1792" alt="Screenshot 2021-08-09 at 23 48 14" src="https://user-images.githubusercontent.com/42480592/128784029-7e17aca3-e50d-44bb-a9df-bb12d3c02771.png">

4. Press the save button. The fork gets created and a permanent link is generated. Copy the link.
<img width="1792" alt="Screenshot 2021-08-09 at 23 48 24" src="https://user-images.githubusercontent.com/42480592/128784082-9498f04a-97a0-46f2-9153-a66d03b47042.png">

5. Open the copied link in a new tab. You will see that the title of the model leaderboard now contains `(FORK)` to denote that this is a fork page. Hover on the info icon present next to the model leaderboard title. It will show you the description that was added in step 3. Sample fork available [here](http://anmol.dynabench.org:3004/tasks/nli/test-desc).
<img width="1792" alt="Screenshot 2021-08-09 at 23 52 16" src="https://user-images.githubusercontent.com/42480592/128784342-29568df3-3f68-449a-b8e2-4e1ee019a787.png">

6. In case no description is added, the info button will not be shown. Sample fork available [here](http://anmol.dynabench.org:3004/tasks/nli/testing-empty-desc).


In order to verify that `/f/` has been removed from fork urls - 
1. As you test the description feature through above steps, note the URL being generate. It follows the schema of `/tasks/<task_code>/<fork_name>`.

In order to verify that `/s` has been removed from snapshot urls - 
1. Visit to the test deployment of this branch [here](http://anmol.dynabench.org:3004/tasks/nli).
2. Click on the camera button as highlighted in the screenshot below.
<img width="1792" alt="Screenshot 2021-08-10 at 00 04 28" src="https://user-images.githubusercontent.com/42480592/128785055-d32e98d7-bf13-4812-8f43-ff4dc16068c6.png">

3. Enter a description if you want to. Press the save button.
<img width="1790" alt="Screenshot 2021-08-10 at 00 04 04" src="https://user-images.githubusercontent.com/42480592/128785039-e19ae1ee-5268-4ea8-86fc-318affd5a76e.png">

4. The snapshot gets created and a permanent link is generated. Copy the link. Note that the link follows the schema of `/tasks/<task_code>/<snapshot_id>`.
<img width="1792" alt="Screenshot 2021-08-10 at 00 05 55" src="https://user-images.githubusercontent.com/42480592/128785160-addb079a-eb85-4624-ac6b-472f0735cafb.png">

5. Open the copied url in a new tab. You will be able to see the corresponding snapshot page. Sample snapshot available [here](http://anmol.dynabench.org:3004/tasks/nli/19).
<img width="1775" alt="Screenshot 2021-08-10 at 00 06 50" src="https://user-images.githubusercontent.com/42480592/128785225-a31b16fa-83ce-45c4-92f7-b0cbf3e07de1.png">
