### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ transformers
 werkzeug
 boto3
 yoyo-migrations
-pandas
+pandas==1.3.0
 sacrebleu
 sklearn
 git+https://github.com/facebookresearch/dynalab.git


### PR DESCRIPTION
The new version of pandas (1.3.1) throws this error when trying to deploy the prod server. I had to keep pandas at 1.3.0 or lower to avoid this problem 

```
Collecting pandas (from -r requirements.txt (line 15))
  Downloading https://files.pythonhosted.org/packages/12/01/360d7f444f910ae16496c07e3f003cb8c641b4ca6c033408a4469a904df3/pandas-1.3.1.tar.gz (4.7MB)
    100% |████████████████████████████████| 4.7MB 114.4MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-4_709h1q/pandas/setup.py", line 18, in <module>
        import numpy
    ModuleNotFoundError: No module named 'numpy'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-4_709h1q/pandas/
sleeping for a bit..
API server down (000)
```