### PR TITLE
Fixes dataset title on Flores grid

### DIFF
--- a/frontends/web/src/components/FloresComponents/FloresGrid.js
+++ b/frontends/web/src/components/FloresComponents/FloresGrid.js
@@ -78,6 +78,7 @@ const FloresGrid = ({ model }) => {
   const [categories, setCategories] = useState([]);
   const [minScore, setMinScore] = useState();
   const [maxScore, setMaxScore] = useState();
+  const [datasetTitle, setDatasetTitle] = useState("");
 
   useEffect(() => {
     const perf_by_tag =
@@ -93,6 +94,9 @@ const FloresGrid = ({ model }) => {
     setMinScore(min);
     setMaxScore(max);
     setCategories(getDict(perf_by_tag).map((a) => a.tag));
+    setDatasetTitle(
+      model.leaderboard_scores[0] && model.leaderboard_scores[0].dataset_name
+    );
   }, [model]);
 
   const getPointCategoryName = (point, dimension) => {
@@ -160,7 +164,7 @@ const FloresGrid = ({ model }) => {
     },
 
     title: {
-      text: "FLORES Devtest Performance Grid (BLEU Score)",
+      text: `${datasetTitle} Performance Grid (BLEU Score)`,
     },
     legend: {
       enabled: true,


### PR DESCRIPTION
This PR 

- Fixes a bug to display a correct dataset title on a Flores model page in the grid section. It uses the key `dataset_name` instead.

<img width="543" alt="Dataset Title" src="https://user-images.githubusercontent.com/84393628/129835750-fefd526a-03ea-4913-9a0e-794fd130bb53.png">
