### PR TITLE
Use ldbd.ly urls for forks

### DIFF
--- a/frontends/web/src/components/TaskLeaderboard/ForkModal.js
+++ b/frontends/web/src/components/TaskLeaderboard/ForkModal.js
@@ -1,7 +1,14 @@
 import React, { useEffect } from "react";
 import { useContext, useState } from "react";
 import UserContext from "../../containers/UserContext";
-import { Button, Form, FormControl, InputGroup, Modal } from "react-bootstrap";
+import {
+  Button,
+  Form,
+  FormControl,
+  InputGroup,
+  Modal,
+  Row,
+} from "react-bootstrap";
 
 const ForkModal = (props) => {
   const context = useContext(UserContext);
@@ -171,10 +178,23 @@ const ForkModal = (props) => {
               <p className="text-break" id="forkLink">
                 {forkUrl}
               </p>
-              <div className="flex text-center flex-column">
-                <Button variant="primary" onClick={copyToClipboard}>
-                  Copy
-                </Button>
+              <div className="d-flex text-center flex-column align-items-center">
+                <Row className="justify-content-between">
+                  <Button
+                    className="mx-1"
+                    variant="primary"
+                    onClick={copyToClipboard}
+                  >
+                    Copy
+                  </Button>
+                  <Button
+                    className="mx-1"
+                    variant="primary"
+                    onClick={() => window.open(forkUrl, "_blank")}
+                  >
+                    Go to URL
+                  </Button>
+                </Row>
                 <p className="my-0">{copySuccess}</p>
               </div>
             </div>

--- a/frontends/web/src/components/TaskLeaderboard/SnapshotModal.js
+++ b/frontends/web/src/components/TaskLeaderboard/SnapshotModal.js
@@ -124,10 +124,23 @@ const SnapshotModal = (props) => {
               <p className="text-break" id="snapshotUrl">
                 {snapshotUrl}
               </p>
-              <div className="flex text-center flex-column">
-                <Button variant="primary" onClick={copyToClipboard}>
-                  Copy
-                </Button>
+              <div className="d-flex text-center flex-column align-items-center">
+                <Row className="justify-content-between">
+                  <Button
+                    className="mx-1"
+                    variant="primary"
+                    onClick={copyToClipboard}
+                  >
+                    Copy
+                  </Button>
+                  <Button
+                    className="mx-1"
+                    variant="primary"
+                    onClick={() => window.open(snapshotUrl, "_blank")}
+                  >
+                    Go to URL
+                  </Button>
+                </Row>
                 <p className="my-0">{copySuccess}</p>
               </div>
             </div>
@@ -139,6 +152,7 @@ const SnapshotModal = (props) => {
           )}
         </Modal.Body>
       )}
+      <Modal.Footer />
     </Modal>
   );
 };


### PR DESCRIPTION
Below are the screenshots to confirm that we use ldbd.ly URLs for forks and snapshots. Note - We were already using ldbd.ly urls for snapshots, just had to make the change for forks.

We also have a new "Go To URL" button which opens up the Fork/Snapshot URL when clicked.

<img width="1792" alt="Screenshot 2021-08-19 at 21 09 19" src="https://user-images.githubusercontent.com/42480592/130137126-d64e251e-ac35-47a0-917d-e1fd987acd6c.png">

<img width="1792" alt="Screenshot 2021-08-19 at 21 10 25" src="https://user-images.githubusercontent.com/42480592/130137135-47ef3f7f-67ee-4fb7-b799-4d7f13267b7b.png">


<img width="1494" alt="Screenshot 2021-08-19 at 20 37 04" src="https://user-images.githubusercontent.com/42480592/130133251-724fbf01-a284-4528-b785-ac9302838f9f.png">
