### PR TITLE
Fix requirements & README for running evaluation perturb script

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -18,7 +18,7 @@ data = {
 Note your input should always contain an `id` or equivalent field to uniquely identify an example. This defines the full set of input keys.
 
 The output format is defined by a `verify_response` method that will be used to validate model response, i.e. a single json object. The model output should encompass both the keys for batch evaluation (i.e. an example identifier passed from input, and a definite prediction) and talking to the endpoint (e.g. some additional insights of the inference such as probability list). To do this, declare a `TaskIO` class that inherits `BaseTaskIO`. Your class has to be called `TaskIO` so don't rename it. This function defines the full set of output keys.
-```
+```python
 from dynalab.tasks.common import BaseTaskIO
 class TaskIO(BaseTaskIO):
     def __init__(self):
@@ -102,10 +102,15 @@ The evaluation metrics, such as accuracy, f1, etc. are implemented in the metric
 ## Perturb datasets
 Use the scripts in scripts folder to perturb datasets and request evaluation.
 For example, to perturb a dataset for task nli to fairness dataset, do
-```
+```bash
 cd scripts
 python perturb.py --s3-uri <s3-uri> --task nli --perturb-prefix fairness
 ```
 The `s3-uri` is the "S3 URI" under "Object overview" in S3, and it should point to an original dataset (i.e. unperturbed version). S3 uri is usually in the format of `s3://{bucket}/{path}`.
+
+Note: If you are running fairness augmentations for the first time, you will first need to run the following command to download the spacy model used to identify entities:
+```bash
+python -m spacy download en_core_web_sm
+```
 
 Follow the prompt to check the output and if everything looks good, copy paste the given command to upload the dataset and request an evaluation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ sacrebleu
 sklearn
 git+https://github.com/facebookresearch/dynalab.git
 sentencepiece
+spacy
+textflint


### PR DESCRIPTION
Some requirements were missing to be able to run the `perturb.py` script. Also needed to run a command to download a `spacy` model in order to run the fairness augmentations. Adding these so that others will be able to run the script more seamlessly.

-----
**Test Plan**

```bash
$ conda create -n dynabench python=3.7 -y && conda activate dynabench
$ pip install -r requirements.txt
$ cd evaluation/scripts
$ python -m spacy download en_core_web_sm

$ python perturb.py --s3-uri s3://evaluation-us-west-1-096166425824/datasets/nli/anli-r3-dev.jsonl --task nli --perturb-prefix fairness
INFO:perturb:Successfully downloaded s3://evaluation-us-west-1-096166425824/datasets/nli/anli-r3-dev.jsonl to anli-r3-dev.jsonl
INFO:perturb:Wrote perturbed dataset to fairness-anli-r3-dev.jsonl
INFO:perturb:Once you are happy with the perturbation, use the following command to upload the data back to S3 and request evaluation
python request_evaluation.py --path fairness-anli-r3-dev.jsonl --task nli --perturb-prefix fairness --base-dataset-name anli-r3-dev
Remove locally downloaded file at anli-r3-dev.jsonl? [Y/n] Y
INFO:perturb:Removed locally downloaded anli-r3-dev.jsonl
```