### PR TITLE
Add paper link to Dynaboard help modal 

### DIFF
--- a/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCard.js
+++ b/frontends/web/src/components/TaskLeaderboard/TaskModelLeaderboardCard.js
@@ -237,11 +237,16 @@ const TaskModelLeaderboardCard = (props) => {
               <Modal.Title>Dynaboard Information</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-              This is a <b>dynamic leaderboard</b>. It allows you, the user, to
-              specify your own utility function over a variety of metrics and
-              datasets, which determines the final ranking of models for this
-              particular task. The default initial weights are specified by the
-              task owners.
+              This is a{" "}
+              <b>
+                <a href={"https://arxiv.org/abs/2106.06052"}>
+                  dynamic leaderboard
+                </a>
+              </b>
+              . It allows you, the user, to specify your own utility function
+              over a variety of metrics and datasets, which determines the final
+              ranking of models for this particular task. The default initial
+              weights are specified by the task owners.
               <br />
               <br />
               There are a few important caveats that you should keep in mind


### PR DESCRIPTION
tiny first PR, as per #727 adds clickable link to the dynaboard paper within the dynaboard help modal
![link](https://user-images.githubusercontent.com/29654756/135577069-3db58bde-d104-43ed-ac87-aab4c836e96e.gif)
