### PR TITLE
Dataset/Prediction upload button spinners

### DIFF
--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -5,7 +5,15 @@
  */
 
 import React from "react";
-import { Container, Row, Form, Col, Card, Button } from "react-bootstrap";
+import {
+  Container,
+  Row,
+  Form,
+  Col,
+  Card,
+  Button,
+  Spinner,
+} from "react-bootstrap";
 import { Formik } from "formik";
 import DragAndDrop from "../DragAndDrop/DragAndDrop";
 
@@ -174,7 +182,15 @@ const Datasets = (props) => {
                               className="submit-btn button-ellipse text-uppercase my-4"
                               disabled={isSubmitting}
                             >
-                              Add New Dataset
+                              {isSubmitting ? (
+                                <Spinner
+                                  as="span"
+                                  animation="border"
+                                  size="sm"
+                                />
+                              ) : (
+                                "Add New Dataset"
+                              )}
                             </Button>
                           ) : null}
                         </Col>

--- a/frontends/web/src/containers/SubmitInterface.js
+++ b/frontends/web/src/containers/SubmitInterface.js
@@ -297,7 +297,7 @@ class SubmitInterface extends React.Component {
                                     size="sm"
                                   />
                                 ) : (
-                                  "Add New Dataset"
+                                  "Upload Predictions"
                                 )}
                               </Button>
                             ) : null}

--- a/frontends/web/src/containers/SubmitInterface.js
+++ b/frontends/web/src/containers/SubmitInterface.js
@@ -13,6 +13,7 @@ import {
   Button,
   Form,
   Modal,
+  Spinner,
 } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { Formik } from "formik";
@@ -289,7 +290,15 @@ class SubmitInterface extends React.Component {
                                 className="submit-btn button-ellipse text-uppercase my-4"
                                 disabled={isSubmitting}
                               >
-                                Save
+                                {isSubmitting ? (
+                                  <Spinner
+                                    as="span"
+                                    animation="border"
+                                    size="sm"
+                                  />
+                                ) : (
+                                  "Add New Dataset"
+                                )}
                               </Button>
                             ) : null}
                           </Col>


### PR DESCRIPTION
As per #728 and #729, text in the upload buttons will now replaced by a spinner while the upload is processing (denoted by `isSubmitting
![spin](https://user-images.githubusercontent.com/29654756/135625996-8174c625-476b-451f-9bd4-4d61b7f33eff.gif)
`)