### PR TITLE
Simplify dataset round selector

### DIFF
--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -260,11 +260,7 @@ const Datasets = (props) => {
                             <Col sm="8">
                               <Form.Control
                                 as="select"
-                                value={
-                                  values.rid === 0
-                                    ? props.task.cur_round
-                                    : values.rid
-                                }
+                                value={values.rid}
                                 onChange={handleChange}
                               >
                                 {[

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -295,17 +295,25 @@ const Datasets = (props) => {
                               <Form.Label column>Round</Form.Label>
                               <Col sm="8">
                                 <Form.Control
-                                  type="number"
-                                  min={1}
-                                  max={props.task.cur_round}
-                                  step={1}
+                                  as="select"
                                   value={
                                     values.rid === 0
                                       ? props.task.cur_round
                                       : values.rid
                                   }
                                   onChange={handleChange}
-                                />
+                                >
+                                  {[
+                                    "None",
+                                    ...[
+                                      ...Array(props.task.cur_round).keys(),
+                                    ].map((i) => i + 1),
+                                  ].map((display, index) => (
+                                    <option key={index} value={index}>
+                                      {display}
+                                    </option>
+                                  ))}
+                                </Form.Control>
                               </Col>
                             </Form.Group>
                           ) : null}

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -265,9 +265,10 @@ const Datasets = (props) => {
                               >
                                 {[
                                   "None",
-                                  ...[
-                                    ...Array(props.task.cur_round).keys(),
-                                  ].map((i) => i + 1),
+                                  ...Array.from(
+                                    { length: props.task.cur_round },
+                                    (x, i) => i + 1
+                                  ),
                                 ].map((display, index) => (
                                   <option key={index} value={index}>
                                     {display}

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -45,19 +45,6 @@ const FileUpload = (props) => {
 };
 
 const Datasets = (props) => {
-  const changeCorrespondsToRound = (
-    corresponds_to_round,
-    default_rid,
-    setFieldValue
-  ) => {
-    const updated_corresponds_to_round = !corresponds_to_round;
-    setFieldValue("corresponds_to_round", updated_corresponds_to_round);
-    if (updated_corresponds_to_round) {
-      setFieldValue("rid", default_rid);
-    } else {
-      setFieldValue("rid", 0); //0 means that the dataset does not correspond to a round.
-    }
-  };
   const delta_metric_configs = JSON.parse(
     props.task.annotation_config_json
   ).delta_metrics;
@@ -197,7 +184,6 @@ const Datasets = (props) => {
                   initialValues={{
                     id: dataset.id,
                     source_url: dataset.source_url,
-                    corresponds_to_round: dataset.rid !== 0,
                     rid: dataset.rid,
                     access_type: dataset.access_type,
                     longdesc: dataset.longdesc,
@@ -267,56 +253,34 @@ const Datasets = (props) => {
                           </Form.Group>
                           <Form.Group
                             as={Row}
+                            controlId="rid"
                             className="py-3 my-0 border-bottom"
                           >
-                            <Form.Label column>
-                              Corresponds to a Round
-                            </Form.Label>
+                            <Form.Label column>Round</Form.Label>
                             <Col sm="8">
-                              <Form.Check
-                                checked={values.corresponds_to_round}
-                                onClick={() =>
-                                  changeCorrespondsToRound(
-                                    values.corresponds_to_round,
-                                    props.task.cur_round,
-                                    setFieldValue
-                                  )
+                              <Form.Control
+                                as="select"
+                                value={
+                                  values.rid === 0
+                                    ? props.task.cur_round
+                                    : values.rid
                                 }
                                 onChange={handleChange}
-                              />
+                              >
+                                {[
+                                  "None",
+                                  ...[
+                                    ...Array(props.task.cur_round).keys(),
+                                  ].map((i) => i + 1),
+                                ].map((display, index) => (
+                                  <option key={index} value={index}>
+                                    {display}
+                                  </option>
+                                ))}
+                              </Form.Control>
                             </Col>
                           </Form.Group>
-                          {values.corresponds_to_round ? (
-                            <Form.Group
-                              as={Row}
-                              controlId="rid"
-                              className="py-3 my-0 border-bottom"
-                            >
-                              <Form.Label column>Round</Form.Label>
-                              <Col sm="8">
-                                <Form.Control
-                                  as="select"
-                                  value={
-                                    values.rid === 0
-                                      ? props.task.cur_round
-                                      : values.rid
-                                  }
-                                  onChange={handleChange}
-                                >
-                                  {[
-                                    "None",
-                                    ...[
-                                      ...Array(props.task.cur_round).keys(),
-                                    ].map((i) => i + 1),
-                                  ].map((display, index) => (
-                                    <option key={index} value={index}>
-                                      {display}
-                                    </option>
-                                  ))}
-                                </Form.Control>
-                              </Col>
-                            </Form.Group>
-                          ) : null}
+
                           <Form.Group
                             as={Row}
                             controlId="longdesc"


### PR DESCRIPTION
As per #733, implements a dropdown selector to indicate the round that a given dataset corresponds to.

Dropdown options will include the rounds available as well as the option `None`, which when selected and submitted carries a value of `rid: 0`


![dropdown](https://user-images.githubusercontent.com/29654756/135742332-b935e344-db1f-4f65-94a9-c878d4c23b49.gif)
