### PR TITLE
Fix install.py not creating config.py file

### DIFF
--- a/api/install.py
+++ b/api/install.py
@@ -11,8 +11,6 @@ import os
 import sqlalchemy as db
 from werkzeug.security import generate_password_hash
 
-from models.base import Base
-
 
 def get_cls_name_helper(ss):
     ret, ii = "", 0
@@ -58,6 +56,8 @@ if __name__ == "__main__":
     else:
         print("Config already exists.")
         from common.config import config
+
+    from models.base import Base
 
     ##
     # Mark all existing migrations done


### PR DESCRIPTION
The current `install.py` doesn't successfully create a `config.py` file and instead throws an error if you run it without an existing config.py

As per #746 this appears to be because `models.base` is imported at the top of the file, and `base.py` attempts to import `config.py`. This PR simply imports `models.base` only after config.py has been confirmed to exist or is generated.