### PR TITLE
Fixed the task code issue

### DIFF
--- a/api/controllers/task_proposals.py
+++ b/api/controllers/task_proposals.py
@@ -72,7 +72,7 @@ def create_task_proposal(credentials):
         bottle.abort(
             400,
             "Invalid task code (no special characters allowed besides underscores "
-            + "and dashes. Atleast one alphabet required)",
+            + "and dashes. Atleast one letter required)",
         )
 
     try:

--- a/api/controllers/task_proposals.py
+++ b/api/controllers/task_proposals.py
@@ -72,7 +72,7 @@ def create_task_proposal(credentials):
         bottle.abort(
             400,
             "Invalid task code (no special characters allowed besides underscores "
-            + "and dashes. Atleast one letter required)",
+            + "and dashes. At least one letter required)",
         )
 
     try:

--- a/api/controllers/task_proposals.py
+++ b/api/controllers/task_proposals.py
@@ -66,11 +66,13 @@ def create_task_proposal(credentials):
     if tm.getByName(data["name"]):
         bottle.abort(400, "Invalid name; this name is already taken")
 
-    if not bool(re.search("^[a-zA-Z0-9_-]*$", data["task_code"])):
+    if not bool(
+        re.search("(?=^[a-zA-Z0-9_-]*$)(?=.*[a-zA-Z].*).*$", data["task_code"])
+    ):
         bottle.abort(
             400,
             "Invalid task code (no special characters allowed besides underscores "
-            + "and dashes)",
+            + "and dashes. Atleast one alphabet required)",
         )
 
     try:

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "webpack": "webpack",
-    "start": "HTTPS=false SSL_CRT_FILE=/home/ubuntu/.ssl/dynabench.org.crt SSL_KEY_FILE=/home/ubuntu/.ssl/dynabench.org-key.pem react-scripts start",
+    "start": "HTTPS=true SSL_CRT_FILE=/home/ubuntu/.ssl/dynabench.org.crt SSL_KEY_FILE=/home/ubuntu/.ssl/dynabench.org-key.pem react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "webpack": "webpack",
-    "start": "HTTPS=true SSL_CRT_FILE=/home/ubuntu/.ssl/dynabench.org.crt SSL_KEY_FILE=/home/ubuntu/.ssl/dynabench.org-key.pem react-scripts start",
+    "start": "HTTPS=false SSL_CRT_FILE=/home/ubuntu/.ssl/dynabench.org.crt SSL_KEY_FILE=/home/ubuntu/.ssl/dynabench.org-key.pem react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/frontends/web/src/components/ProfilePageComponents/TaskProposalSubPage.js
+++ b/frontends/web/src/components/ProfilePageComponents/TaskProposalSubPage.js
@@ -83,9 +83,16 @@ const TaskProposalForm = (props) => {
                       </Form.Label>
                       <Col sm="8">
                         <Form.Control
+                          pattern=".*[a-zA-Z].*"
+                          title="Task code must contain at least one letter"
+                          type="text"
                           onChange={handleChange}
                           defaultValue={values.task_code}
                         />
+                        <Form.Text id="taskCodeHelpBlock" muted>
+                          This is a short string that will be the url for your
+                          task. e.g "nli" for "Natural Language Inference"
+                        </Form.Text>
                       </Col>
                     </Form.Group>
                     <Form.Group

--- a/frontends/web/src/components/ProfilePageComponents/TaskProposalSubPage.js
+++ b/frontends/web/src/components/ProfilePageComponents/TaskProposalSubPage.js
@@ -83,9 +83,6 @@ const TaskProposalForm = (props) => {
                       </Form.Label>
                       <Col sm="8">
                         <Form.Control
-                          pattern=".*[a-zA-Z].*"
-                          title="Task code must contain at least one letter"
-                          type="text"
                           onChange={handleChange}
                           defaultValue={values.task_code}
                         />


### PR DESCRIPTION
This PR fixes the issue where task codes which were purely numeric caused their respective task page to not load.

The issue has been fixed by adding a regex filter to the form field related to the task code which expects atleast 1 alphabet. Some helper text has also been added below the form field to give users an idea of what they need to enter for the task code.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/48560219/136010937-b3e379a4-f361-4969-b98b-efb472671d3a.png">

<img width="800" alt="image" src="https://user-images.githubusercontent.com/48560219/136010963-e2d8c086-83d8-484c-8a4b-1ecb4c95852f.png">

This closes #743 