### PR TITLE
Task Owner can Delete Datasets

### DIFF
--- a/api/common/cors.py
+++ b/api/common/cors.py
@@ -34,7 +34,9 @@ def add_cors_headers():
 
     bottle.default_app()
     bottle.response.headers["Access-Control-Allow-Origin"] = origin
-    bottle.response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, OPTIONS"
+    bottle.response.headers[
+        "Access-Control-Allow-Methods"
+    ] = "GET, POST, PUT, DELETE, OPTIONS"
     bottle.response.headers[
         "Access-Control-Allow-Headers"
     ] = "Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token, Authorization"

--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -60,7 +60,7 @@ def delete(credentials, did):
 
     delta_metric_types = [
         config["type"]
-        for config in json.loads(task.annotation_config_json)["delta_metrics"]
+        for config in ujson.loads(task.annotation_config_json)["delta_metrics"]
     ]
     delta_metric_types.append(None)
 
@@ -149,7 +149,7 @@ def create(credentials, tid, name):
                 tmp.close()
                 response = s3_client.upload_file(
                     tmp.name,
-                    "dynabench-dev",
+                    task.s3_bucket,
                     get_data_s3_path(task.task_code, name + ".jsonl", perturb_prefix),
                 )
                 os.remove(tmp.name)

--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -48,6 +48,17 @@ def update(credentials, did):
     return util.json_encode({"success": "ok"})
 
 
+@bottle.delete("/datasets/delete/<did:int>")
+@_auth.requires_auth
+def delete(credentials, did):
+    dm = DatasetModel()
+    dataset = dm.get(did)
+    ensure_owner_or_admin(dataset.tid, credentials["id"])
+
+    dm.delete(dataset)
+    return util.json_encode({"success": "ok"})
+
+
 @bottle.post("/datasets/create/<tid:int>/<name>")
 @_auth.requires_auth
 def create(credentials, tid, name):

--- a/frontends/web/public/trash.svg
+++ b/frontends/web/public/trash.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
   <path fill="#FFFFFF" d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
   <path fill="#FFFFFF" fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
 </svg>

--- a/frontends/web/public/trash.svg
+++ b/frontends/web/public/trash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+  <path fill="#FFFFFF" d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+  <path fill="#FFFFFF" fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+</svg>

--- a/frontends/web/public/trash.svg
+++ b/frontends/web/public/trash.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="#FFFFFF" d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
-  <path fill="#FFFFFF" fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
-</svg>

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -638,6 +638,12 @@ export default class ApiService {
     });
   }
 
+  deleteDataset(did) {
+    return this.fetch(`${this.domain}/datasets/delete/${did}`, {
+      method: "DELETE",
+    });
+  }
+
   uploadPredictions(tid, modelName, files) {
     const token = this.getToken();
     const formData = new FormData();

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -224,12 +224,17 @@ const Datasets = (props) => {
                             className="py-3 my-0 border-bottom"
                           >
                             <Form.Label column>Name</Form.Label>
-                            <Col sm="8">
+                            <Col sm="6">
                               <Form.Control
                                 disabled
                                 plaintext
                                 defaultValue={dataset.name}
                               />
+                            </Col>
+                            <Col sm="2">
+                              <Button variant="danger" className="btn-block">
+                                Delete <img src="/trash.svg" alt="Delete" />
+                              </Button>
                             </Col>
                           </Form.Group>
                           <Form.Group

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -232,7 +232,13 @@ const Datasets = (props) => {
                               />
                             </Col>
                             <Col sm="2">
-                              <Button variant="danger" className="btn-block">
+                              <Button
+                                variant="danger"
+                                className="btn-block"
+                                onClick={() => {
+                                  props.handleDatasetDelete(values.id);
+                                }}
+                              >
                                 Delete <img src="/trash.svg" alt="Delete" />
                               </Button>
                             </Col>

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -239,7 +239,7 @@ const Datasets = (props) => {
                                   props.handleDatasetDelete(values.id);
                                 }}
                               >
-                                Delete <img src="/trash.svg" alt="Delete" />
+                                Delete <i class="fas fa-trash-alt"></i>
                               </Button>
                             </Col>
                           </Form.Group>

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -239,7 +239,7 @@ const Datasets = (props) => {
                                   props.handleDatasetDelete(values.id);
                                 }}
                               >
-                                Delete <i class="fas fa-trash-alt"></i>
+                                <i class="fas fa-trash-alt"></i>
                               </Button>
                             </Col>
                           </Form.Group>

--- a/frontends/web/src/containers/TaskOwnerPage.js
+++ b/frontends/web/src/containers/TaskOwnerPage.js
@@ -339,6 +339,12 @@ class TaskOwnerPage extends React.Component {
     );
   };
 
+  handleDatasetDelete = (did) => {
+    this.context.api.deleteDataset(did).then((result) => {
+      this.fetchDatasets();
+    });
+  };
+
   handleRoundUpdate = (
     values,
     { setFieldError, setSubmitting, setFieldValue, resetForm }
@@ -537,6 +543,7 @@ class TaskOwnerPage extends React.Component {
                     handleUploadAndCreateDataset={
                       this.handleUploadAndCreateDataset
                     }
+                    handleDatasetDelete={this.handleDatasetDelete}
                   />
                 ) : null}
               </>


### PR DESCRIPTION
As per https://github.com/facebookresearch/dynabench/issues/762, introduces simple feature to allow a task owner to delete datasets for the task

the endpoint is simply:
```
DELETE /datasets/delete/<did:int>
```

![delete](https://user-images.githubusercontent.com/29654756/136411996-e23eb84f-60c3-422d-9180-0ad181c0d9a4.gif)

