### PR TITLE
replace `json` with `ujson>=4.2.0`

### DIFF
--- a/api/bottle.py
+++ b/api/bottle.py
@@ -40,6 +40,8 @@ from traceback import format_exc, print_exc
 from types import FunctionType
 from unicodedata import normalize
 
+from ujson import dumps as json_dumps, loads as json_lds
+
 
 __author__ = "Marcel Hellkamp"
 __version__ = "0.13-dev"
@@ -106,11 +108,6 @@ if __name__ == "__main__":
 # Imports and Python 2/3 unification ##########################################
 ###############################################################################
 
-
-try:
-    from ujson import dumps as json_dumps, loads as json_lds
-except ImportError:
-    from json import dumps as json_dumps, loads as json_lds
 
 # inspect.getargspec was removed in Python 3.6, use
 # Signature-based version where we can (Python 3.3+)

--- a/api/common/helpers.py
+++ b/api/common/helpers.py
@@ -4,7 +4,6 @@
 
 import datetime
 import decimal
-import json
 from urllib.parse import urlparse
 
 import bottle
@@ -12,6 +11,7 @@ import sqlalchemy as db
 from sqlalchemy.orm import lazyload
 
 import common.auth as _auth
+import ujson
 from common.logging import logger
 from models.example import ExampleModel
 from models.round import RoundModel
@@ -39,7 +39,7 @@ def _alchemyencoder(obj):
 
 
 def json_encode(obj):
-    return json.dumps(obj, default=_alchemyencoder)
+    return ujson.dumps(obj, default=_alchemyencoder)
 
 
 def is_current_user(uid, credentials=None):
@@ -207,7 +207,7 @@ def get_round_data_for_export(tid, rid):
 
     for example, validation_ids in examples_with_validation_ids:
         if example.uid or (
-            example.metadata_json and json.loads(example.metadata_json)["annotator_id"]
+            example.metadata_json and ujson.loads(example.metadata_json)["annotator_id"]
         ):
             example_and_validations_dict = example.to_dict()
             if example.uid:
@@ -217,7 +217,7 @@ def get_round_data_for_export(tid, rid):
             else:
                 example_and_validations_dict["anon_uid"] = get_anon_uid_with_cache(
                     secret,
-                    json.loads(example.metadata_json)["annotator_id"],
+                    ujson.loads(example.metadata_json)["annotator_id"],
                     turk_cache,
                 )
             example_and_validations_dict["validations"] = []
@@ -228,7 +228,7 @@ def get_round_data_for_export(tid, rid):
                 validation = validation_dict[validation_id]
                 if validation.uid or (
                     validation.metadata_json
-                    and json.loads(validation.metadata_json)["annotator_id"]
+                    and ujson.loads(validation.metadata_json)["annotator_id"]
                 ):
                     if validation.uid:
                         validation_info = [
@@ -244,13 +244,13 @@ def get_round_data_for_export(tid, rid):
                             validation.mode.name,
                             get_anon_uid_with_cache(
                                 secret + "-validator",
-                                json.loads(validation.metadata_json)["annotator_id"],
+                                ujson.loads(validation.metadata_json)["annotator_id"],
                                 cache,
                             ),
                         ]
 
                     if validation.metadata_json:
-                        validation_info.append(json.loads(validation.metadata_json))
+                        validation_info.append(ujson.loads(validation.metadata_json))
 
                     example_and_validations_dict["validations"].append(validation_info)
             example_and_validations_dicts.append(example_and_validations_dict)

--- a/api/controllers/contexts.py
+++ b/api/controllers/contexts.py
@@ -2,13 +2,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 from urllib.parse import parse_qs
 
 import bottle
 
 import common.auth as _auth
 import common.helpers as util
+import ujson
 from common.logging import logger
 from models.context import Context, ContextModel
 from models.round import RoundModel
@@ -96,7 +96,8 @@ def do_upload(credentials, tid, rid):
 
     try:
         parsed_upload_data = [
-            json.loads(line) for line in upload.file.read().decode("utf-8").splitlines()
+            ujson.loads(line)
+            for line in upload.file.read().decode("utf-8").splitlines()
         ]
         for context_info in parsed_upload_data:
             if (
@@ -118,8 +119,8 @@ def do_upload(credentials, tid, rid):
     for context_info in parsed_upload_data:
         c = Context(
             r_realid=r_realid,
-            context_json=json.dumps(context_info["context"]),
-            metadata_json=json.dumps(context_info["metadata"]),
+            context_json=ujson.dumps(context_info["context"]),
+            metadata_json=ujson.dumps(context_info["metadata"]),
             tag=context_info["tag"],
         )
         contexts_to_add.append(c)

--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -2,7 +2,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import os
 import re
 import sys
@@ -13,6 +12,7 @@ import bottle
 
 import common.auth as _auth
 import common.helpers as util
+import ujson
 from common.config import config
 from common.logging import logger
 from models.dataset import AccessTypeEnum, DatasetModel
@@ -68,7 +68,7 @@ def create(credentials, tid, name):
     delta_dataset_uploads = []
     delta_metric_types = [
         config["type"]
-        for config in json.loads(task.annotation_config_json)["delta_metrics"]
+        for config in ujson.loads(task.annotation_config_json)["delta_metrics"]
     ]
     for delta_metric_type in delta_metric_types:
         delta_dataset_uploads.append(
@@ -82,7 +82,7 @@ def create(credentials, tid, name):
     for upload, perturb_prefix in uploads:
         try:
             parsed_upload = [
-                json.loads(line)
+                ujson.loads(line)
                 for line in upload.file.read().decode("utf-8").splitlines()
             ]
             for io in parsed_upload:
@@ -110,7 +110,7 @@ def create(credentials, tid, name):
             )
             with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp:
                 for datum in parsed_upload:
-                    tmp.write(json.dumps(datum) + "\n")
+                    tmp.write(ujson.dumps(datum) + "\n")
                 tmp.close()
                 response = s3_client.upload_file(
                     tmp.name,

--- a/api/controllers/endpoints.py
+++ b/api/controllers/endpoints.py
@@ -2,11 +2,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
-
 import bottle
 
 import common.auth as _auth
+import ujson
 from common.logging import logger
 
 
@@ -41,7 +40,7 @@ def invoke_endpoint(credentials, endpoint):
         response = sagemaker_client.invoke_endpoint(
             EndpointName=endpoint,
             ContentType="application/json",
-            Body=json.dumps(payload),
+            Body=ujson.dumps(payload),
         )
     except Exception as error_message:
         logger.info("Error in prediction: %s" % (error_message))

--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -2,13 +2,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 from urllib.parse import parse_qs
 
 import bottle
 
 import common.auth as _auth
 import common.helpers as util
+import ujson
 from common.logging import logger
 from models.badge import BadgeModel
 from models.context import ContextModel
@@ -134,7 +134,7 @@ def update_example(credentials, eid):
         if credentials["id"] == "turk":
             if not util.check_fields(data, ["uid"]):
                 bottle.abort(400, "Missing data")
-            metadata = json.loads(example.metadata_json)
+            metadata = ujson.loads(example.metadata_json)
             if (
                 "annotator_id" not in metadata
                 or metadata["annotator_id"] != data["uid"]
@@ -168,8 +168,8 @@ def update_example(credentials, eid):
             cm = ContextModel()
             context = cm.get(example.cid)
             all_user_annotation_data = {}
-            all_user_annotation_data.update(json.loads(context.context_json))
-            all_user_annotation_data.update(json.loads(example.input_json))
+            all_user_annotation_data.update(ujson.loads(context.context_json))
+            all_user_annotation_data.update(ujson.loads(example.input_json))
             all_user_annotation_data.update(data["metadata"])
             if (
                 not TaskModel()
@@ -180,10 +180,10 @@ def update_example(credentials, eid):
             # Make sure to keep fields in the metadata_json from before if they aren't
             # in the new metadata_json
             if example.metadata_json is not None:
-                for key, value in json.loads(example.metadata_json).items():
+                for key, value in ujson.loads(example.metadata_json).items():
                     if key not in data["metadata"]:
                         data["metadata"][key] = value
-            data["metadata_json"] = json.dumps(data["metadata"])
+            data["metadata_json"] = ujson.dumps(data["metadata"])
             del data["metadata"]
 
         logger.info(f"Updating example {example.id} with {data}")
@@ -214,7 +214,7 @@ def evaluate_model_correctness():
 
     tm = TaskModel()
     task = tm.get(data["tid"])
-    annotation_config = json.loads(task.annotation_config_json)
+    annotation_config = ujson.loads(task.annotation_config_json)
     model_wrong_metric = model_wrong_metrics[
         annotation_config["model_wrong_metric"]["type"]
     ]

--- a/api/controllers/models.py
+++ b/api/controllers/models.py
@@ -2,7 +2,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import secrets
 import sys
 import tempfile
@@ -14,6 +13,7 @@ import sqlalchemy as db
 
 import common.auth as _auth
 import common.helpers as util
+import ujson
 from common.config import config
 from common.logging import logger
 from models.badge import BadgeModel
@@ -85,7 +85,7 @@ def do_upload_via_predictions(credentials, tid, model_name):
     for name, upload in uploads.items():
         try:
             parsed_upload = [
-                json.loads(line)
+                ujson.loads(line)
                 for line in upload.file.read().decode("utf-8").splitlines()
             ]
             for io in parsed_upload:
@@ -127,7 +127,7 @@ def do_upload_via_predictions(credentials, tid, model_name):
                     # Why do we use two seperate names for the same thing? Can we make
                     # this consistent?
                     del datum["uid"]
-                    tmp.write(json.dumps(datum) + "\n")
+                    tmp.write(ujson.dumps(datum) + "\n")
                 tmp.close()
                 ret = _eval_dataset(dataset_name, endpoint_name, model, task, tmp.name)
                 status_dict.update(ret)
@@ -405,7 +405,7 @@ def upload_to_s3(credentials):
     sqs = session.resource("sqs")
     queue = sqs.get_queue_by_name(QueueName=config["builder_sqs_queue"])
     queue.send_message(
-        MessageBody=json.dumps(
+        MessageBody=ujson.dumps(
             {"model_id": model.id, "s3_uri": f"s3://{bucket_name}/{s3_path}"}
         )
     )

--- a/api/controllers/tasks.py
+++ b/api/controllers/tasks.py
@@ -2,7 +2,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import secrets
 from urllib.parse import parse_qs, quote
 
@@ -12,6 +11,7 @@ import uuid
 
 import common.auth as _auth
 import common.helpers as util
+import ujson
 from common.logging import logger
 from models.dataset import Dataset, DatasetModel
 from models.leaderboard_configuration import LeaderboardConfigurationModel
@@ -428,7 +428,7 @@ def activate(credentials, tid):
         )
 
     try:
-        Task.verify_annotation_config(json.loads(data["annotation_config_json"]))
+        Task.verify_annotation_config(ujson.loads(data["annotation_config_json"]))
     except Exception as ex:
         logger.exception("Invalid annotation config: (%s)" % (ex))
         bottle.abort(400, "Invalid annotation config")
@@ -776,7 +776,7 @@ def get_task_trends(tid):
         for model in sm.dbs.query(Model):
             mid_to_name[model.id] = model.name
 
-        for model_results in json.loads(dynaboard_response)["data"]:
+        for model_results in ujson.loads(dynaboard_response)["data"]:
             for dataset_results in model_results["datasets"]:
                 rid = did_to_rid[dataset_results["id"]]
                 if rid != 0:
@@ -907,7 +907,7 @@ def create_leaderboard_snapshot(credentials, tid):
         data["totalCount"],
         0,
     )
-    dynaboard_info = json.loads(dynaboard_info)
+    dynaboard_info = ujson.loads(dynaboard_info)
     dynaboard_info["metricWeights"] = data["metricWeights"]
     dynaboard_info["datasetWeights"] = data["datasetWeights"]
     dynaboard_info["miscInfoJson"] = {"sort": data["sort"]}
@@ -966,7 +966,7 @@ def construct_model_board_response_json(query_result, total_count):
     for d in query_result:
         obj = dict(zip(fields, d))
         if obj.get("metadata_json", None):
-            obj["metadata_json"] = json.loads(obj["metadata_json"])
+            obj["metadata_json"] = ujson.loads(obj["metadata_json"])
             # Check tags for every model to allow flexibility for adding or
             # removing tags in future
             if "perf_by_tag" in obj["metadata_json"]:

--- a/api/controllers/validations.py
+++ b/api/controllers/validations.py
@@ -2,12 +2,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
-
 import bottle
 
 import common.auth as _auth
 import common.helpers as util
+import ujson
 from models.badge import BadgeModel
 from models.context import ContextModel
 from models.example import ExampleModel
@@ -73,7 +72,7 @@ def validate_example(credentials, eid):
     if credentials["id"] == "turk":
         if not util.check_fields(data, ["uid"]):
             bottle.abort(400, "Missing data")
-        example_metadata = json.loads(example.metadata_json)
+        example_metadata = ujson.loads(example.metadata_json)
         if (
             "annotator_id" not in example_metadata
             or example_metadata["annotator_id"] == data["uid"]
@@ -82,7 +81,7 @@ def validate_example(credentials, eid):
         current_validation_metadata["annotator_id"] = data["uid"]
         for validation in validations:
             if (
-                json.loads(validation.metadata_json)["annotator_id"]
+                ujson.loads(validation.metadata_json)["annotator_id"]
                 == current_validation_metadata["annotator_id"]
             ):
                 bottle.abort(
@@ -122,7 +121,7 @@ def validate_example(credentials, eid):
                         example.uid, context.r_realid
                     )
                 if user.metadata_json is not None:
-                    user_metadata = json.loads(user.metadata_json)
+                    user_metadata = ujson.loads(user.metadata_json)
                     if (
                         task.task_code + "_fooling_no_verified_incorrect_or_flagged"
                         in user_metadata
@@ -140,7 +139,7 @@ def validate_example(credentials, eid):
                     user_metadata = {
                         task.task_code + "_fooling_no_verified_incorrect_or_flagged": 0
                     }
-                user.metadata_json = json.dumps(user_metadata)
+                user.metadata_json = ujson.dumps(user_metadata)
                 um.dbs.commit()
 
     ret = example.to_dict()

--- a/api/install.py
+++ b/api/install.py
@@ -5,11 +5,12 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib
-import json
 import os
 
 import sqlalchemy as db
 from werkzeug.security import generate_password_hash
+
+import ujson
 
 
 def get_cls_name_helper(ss):
@@ -51,7 +52,7 @@ if __name__ == "__main__":
             config[field] = tmp
 
         with open("common/config.py", "w") as fw:
-            fw.write("config = " + json.dumps(config, indent=4, sort_keys=True))
+            fw.write("config = " + ujson.dumps(config, indent=4, sort_keys=True))
             print("Wrote config to common/config.py - feel free to edit.")
     else:
         print("Config already exists.")
@@ -115,7 +116,7 @@ if __name__ == "__main__":
         name="Test",
         task_code="test",
         desc="Your test task",
-        annotation_config_json=json.dumps({}),
+        annotation_config_json=ujson.dumps({}),
         cur_round=1,
     )
     dbs.add(t)

--- a/api/models/badge.py
+++ b/api/models/badge.py
@@ -3,10 +3,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import datetime
-import json
 
 import sqlalchemy as db
 
+import ujson
 from common.logging import logger
 
 from .base import Base, BaseModel
@@ -195,14 +195,14 @@ class BadgeModel(BaseModel):
 
     def incrementUserMetadataField(self, user, key, value=1):
         if user.metadata_json:
-            metadata = json.loads(user.metadata_json)
+            metadata = ujson.loads(user.metadata_json)
             if key in metadata:
                 metadata[key] += value
             else:
                 metadata[key] = value
         else:
             metadata = {key: value}
-        user.metadata_json = json.dumps(metadata)
+        user.metadata_json = ujson.dumps(metadata)
         self.dbs.commit()
 
     def getFieldsFromMetadata(self, metadata, value_if_absent, fields):
@@ -267,7 +267,7 @@ class BadgeModel(BaseModel):
 
         for user in users:
             if user.metadata_json:
-                metadata = json.loads(user.metadata_json)
+                metadata = ujson.loads(user.metadata_json)
             else:
                 metadata = {}
 
@@ -457,7 +457,7 @@ class BadgeModel(BaseModel):
                 metadata["async_badges_to_award"] = async_badges_to_award
             else:
                 metadata["async_badges_to_award"] += async_badges_to_award
-            user.metadata_json = json.dumps(metadata)
+            user.metadata_json = ujson.dumps(metadata)
 
         self.createNotificationsAndRemoveBadges(
             badges_to_remove, "BADGE_REMOVED_STREAK"
@@ -473,7 +473,7 @@ class BadgeModel(BaseModel):
         badges_to_remove = []
         existing_badges = self.getByUid(user.id)
         models_published = self.getFieldsFromMetadata(
-            json.loads(user.metadata_json),
+            ujson.loads(user.metadata_json),
             0,
             [
                 task_name + "_models_published"
@@ -486,7 +486,7 @@ class BadgeModel(BaseModel):
             if (
                 (
                     badge.name == "SOTA"
-                    and json.loads(badge.metadata_json)["mid"] == model.id
+                    and ujson.loads(badge.metadata_json)["mid"] == model.id
                 )
                 or (badge.name == "SERIAL_PREDICTOR" and models_published_sum < 2)
                 or (badge.name == "MODEL_BUILDER" and models_published_sum < 1)
@@ -507,7 +507,7 @@ class BadgeModel(BaseModel):
         if (
             self.lengthOfFilteredList(
                 lambda badge: badge.name == "SOTA"
-                and json.loads(badge.metadata_json)["mid"] == model.id,
+                and ujson.loads(badge.metadata_json)["mid"] == model.id,
                 existing_badges,
             )
             == 0
@@ -526,13 +526,13 @@ class BadgeModel(BaseModel):
                     ):
                         badges_to_add.append(
                             self._badgeobj(
-                                user.id, "SOTA", json.dumps({"mid": model.id})
+                                user.id, "SOTA", ujson.dumps({"mid": model.id})
                             )
                         )
                         break
 
         models_published = self.getFieldsFromMetadata(
-            json.loads(user.metadata_json),
+            ujson.loads(user.metadata_json),
             0,
             [
                 task_name + "_models_published"
@@ -578,12 +578,12 @@ class BadgeModel(BaseModel):
         badge_names = []
 
         if user.metadata_json:
-            metadata = json.loads(user.metadata_json)
+            metadata = ujson.loads(user.metadata_json)
             if "async_badges_to_award" in metadata:
                 for name in metadata["async_badges_to_award"]:
                     badge_names.append(name)
                 metadata["async_badges_to_award"] = []
-                user.metadata_json = json.dumps(metadata)
+                user.metadata_json = ujson.dumps(metadata)
                 self.dbs.commit()
 
         return badge_names
@@ -629,7 +629,7 @@ class BadgeModel(BaseModel):
         # Contributor badges
         existing_badges = self.getByUid(user.id)
         if user.metadata_json:
-            metadata = json.loads(user.metadata_json)
+            metadata = ujson.loads(user.metadata_json)
             for task_name in self.task_code_to_badge_name:
                 if task_name + "_fooling_no_verified_incorrect_or_flagged" in metadata:
                     for (
@@ -728,7 +728,7 @@ class BadgeModel(BaseModel):
 
         # Contributor badges
         if user.metadata_json:
-            metadata = json.loads(user.metadata_json)
+            metadata = ujson.loads(user.metadata_json)
             num_created_by_task = self.getFieldsFromMetadata(
                 metadata,
                 0,

--- a/api/models/example.py
+++ b/api/models/example.py
@@ -3,13 +3,13 @@
 # LICENSE file in the root directory of this source tree.
 
 import hashlib
-import json
 import tempfile
 
 import sqlalchemy as db
 from dynalab.tasks.task_io import TaskIO
 from sqlalchemy import case
 
+import ujson
 from common.logging import logger
 from models.context import Context
 from models.model import Model
@@ -102,7 +102,7 @@ class ExampleModel(BaseModel):
         tm = TaskModel()
         task = tm.get(tid)
 
-        context = json.loads(c.context_json)
+        context = ujson.loads(c.context_json)
 
         all_user_annotation_data = {}
         all_user_annotation_data.update(context)
@@ -134,9 +134,9 @@ class ExampleModel(BaseModel):
             ):  # This means that we have a dynalab model
 
                 with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp:
-                    annotation_config = json.loads(task.annotation_config_json)
+                    annotation_config = ujson.loads(task.annotation_config_json)
                     tmp.write(
-                        json.dumps(
+                        ujson.dumps(
                             {
                                 "annotation_config": annotation_config,
                                 "task": task.task_code,
@@ -148,7 +148,7 @@ class ExampleModel(BaseModel):
 
                 # This is to check if we have a pre-dynatask dynalab model
                 with tempfile.NamedTemporaryFile(mode="w+", delete=False) as tmp:
-                    annotation_config = json.loads(task.annotation_config_json)
+                    annotation_config = ujson.loads(task.annotation_config_json)
                     if task.task_code in ("hs", "sentiment"):
                         annotation_config["context"] = []
                     annotation_config["output"] = [
@@ -157,7 +157,7 @@ class ExampleModel(BaseModel):
                         if obj["type"] not in ("multiclass_probs", "conf")
                     ]
                     tmp.write(
-                        json.dumps(
+                        ujson.dumps(
                             {
                                 "annotation_config": annotation_config,
                                 "task": task.task_code,
@@ -277,11 +277,11 @@ class ExampleModel(BaseModel):
         try:
             e = Example(
                 context=c,
-                input_json=json.dumps(input),
-                output_json=json.dumps(output),
+                input_json=ujson.dumps(input),
+                output_json=ujson.dumps(output),
                 model_wrong=model_wrong,
                 generated_datetime=db.sql.func.now(),
-                metadata_json=json.dumps(metadata),
+                metadata_json=ujson.dumps(metadata),
                 tag=tag,
                 model_endpoint_name=model_endpoint_name,
             )
@@ -306,7 +306,7 @@ class ExampleModel(BaseModel):
         tid = context.round.task.id
         rid = context.round.rid
         secret = context.round.secret
-        context_str = list(json.loads(context.context_json).values())[0]
+        context_str = list(ujson.loads(context.context_json).values())[0]
 
         fields_to_sign = []
         fields_to_sign.append(pred_str.encode("utf-8"))

--- a/api/models/score.py
+++ b/api/models/score.py
@@ -2,12 +2,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import math
 
 import pandas as pd
 import sqlalchemy as db
 
+import ujson
 from common import helpers as util
 from models.dataset import AccessTypeEnum, Dataset
 from models.round import Round
@@ -116,7 +116,7 @@ class ScoreModel(BaseModel):
             if dataset.name not in dataset_name_to_tag_performances:
                 dataset_name_to_tag_performances[dataset.name] = {}
             if score.metadata_json is not None:
-                metadata = json.loads(score.metadata_json)
+                metadata = ujson.loads(score.metadata_json)
                 for tag_perf_dict in metadata.get("perf_by_tag", []):
 
                     # if we want only the top performance for a specific tag,
@@ -294,7 +294,7 @@ class ScoreModel(BaseModel):
             for metric_info in ordered_metrics_with_weight_and_conversion:
                 if (score.to_dict().get(metric_info["field_name"], None) is None) and (
                     score.metadata_json is None
-                    or json.loads(score.metadata_json).get(
+                    or ujson.loads(score.metadata_json).get(
                         metric_info["field_name"], None
                     )
                     is None
@@ -331,7 +331,7 @@ class ScoreModel(BaseModel):
                 for field_name in dataset_results_dict[dataset.id]:
                     result = score.to_dict().get(field_name, None)
                     if result is None:
-                        result = json.loads(score.metadata_json)[field_name]
+                        result = ujson.loads(score.metadata_json)[field_name]
                     dataset_results_dict[dataset.id][field_name].append(result)
 
         # Average the results accross datasets.

--- a/api/models/task.py
+++ b/api/models/task.py
@@ -2,13 +2,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import sys
 
 import enum
 import sqlalchemy as db
 from transformers.data.metrics.squad_metrics import compute_f1
 
+import ujson
 from common.logging import logger
 
 from .base import Base, BaseModel
@@ -501,7 +501,7 @@ class Task(Base):
     def verify_annotation(self, data, mode=AnnotationVerifierMode.default):
         name_to_constructor_args = {}
         name_to_type = {}
-        annotation_config = json.loads(self.annotation_config_json)
+        annotation_config = ujson.loads(self.annotation_config_json)
         annotation_config_objs = (
             annotation_config["context"]
             + annotation_config["output"]
@@ -617,7 +617,7 @@ class TaskModel(BaseModel):
             r_dict = r.to_dict()
             t_dict["ordered_scoring_datasets"] = scoring_dataset_list
             t_dict["ordered_datasets"] = dataset_list
-            annotation_config = json.loads(t_dict["annotation_config_json"])
+            annotation_config = ujson.loads(t_dict["annotation_config_json"])
             # TODO: make the frontend use perf_metric instead of perf_metric_field_name?
             if "perf_metric" in annotation_config:
                 t_dict["perf_metric_field_name"] = annotation_config["perf_metric"][

--- a/api/models/validation.py
+++ b/api/models/validation.py
@@ -2,11 +2,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
-
 import enum
 import sqlalchemy as db
 
+import ujson
 from common.logging import logger
 
 from .base import Base, BaseModel
@@ -54,7 +53,7 @@ class ValidationModel(BaseModel):
         try:
             if uid == "turk":
                 validation = Validation(
-                    eid=eid, label=label, mode=mode, metadata_json=json.dumps(metadata)
+                    eid=eid, label=label, mode=mode, metadata_json=ujson.dumps(metadata)
                 )
             else:
                 validation = Validation(
@@ -62,7 +61,7 @@ class ValidationModel(BaseModel):
                     eid=eid,
                     label=label,
                     mode=mode,
-                    metadata_json=json.dumps(metadata),
+                    metadata_json=ujson.dumps(metadata),
                 )
             self.dbs.add(validation)
             return self.dbs.commit()

--- a/api/tools/adjust_vqa_test2015_tag.py
+++ b/api/tools/adjust_vqa_test2015_tag.py
@@ -4,7 +4,7 @@
 
 # flake8: noqa
 
-import json  # isort:skip
+import ujson  # isort:skip
 import os  # isort:skip
 import sys  # isort:skip
 import sqlalchemy as db
@@ -23,7 +23,7 @@ from models.task import TaskModel  # isort:skip
 def update_tag(filename, dbs, assert_length, old_tag, new_tag):
     anns = None
     with open(filename) as jsonFile:
-        anns = json.load(jsonFile)
+        anns = ujson.load(jsonFile)
 
     images_list = []
     for ann in anns["questions"]:

--- a/api/tools/populate_anli.py
+++ b/api/tools/populate_anli.py
@@ -3,11 +3,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import codecs
-import json
 import os
 import secrets
 import sys
 
+import ujson
 from models.base import dbs
 from models.context import Context
 from models.round import Round, RoundModel
@@ -26,7 +26,7 @@ for n in contexts.keys():
         fpath = os.path.join("anli_v0.1", "R" + n, fname)
         print(fpath)
         contexts[n].extend(
-            [json.loads(ll)["context"] for ll in codecs.open(fpath, "r", "utf8")]
+            [ujson.loads(ll)["context"] for ll in codecs.open(fpath, "r", "utf8")]
         )
     contexts[n] = list(set(contexts[n]))
 print({k: len(contexts[k]) for k in contexts.keys()})

--- a/api/tools/populate_anli_r4.py
+++ b/api/tools/populate_anli_r4.py
@@ -2,10 +2,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import secrets
 import sys
 
+import ujson
 from models.base import dbs
 from models.context import Context
 from models.round import Round, RoundModel
@@ -20,7 +20,7 @@ def load_jsonl(filename, debug_num=None):
     with open(filename, encoding="utf-8", mode="r") as in_f:
         print("Load Jsonl:", filename)
         for line in in_f:
-            item = json.loads(line.strip())
+            item = ujson.loads(line.strip())
             d_list.append(item)
             if debug_num is not None and 0 < debug_num == len(d_list):
                 break

--- a/api/tools/populate_nq.py
+++ b/api/tools/populate_nq.py
@@ -2,13 +2,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import os
 import secrets
 import sys
 
 import pandas as pd
 
+import ujson
 from models.context import Context
 from models.round import Round, RoundModel
 from models.task import TaskModel
@@ -30,7 +30,7 @@ for n in contexts.keys():
         this_contexts2.append(
             {
                 "context": c,
-                "metadata_json": json.dumps(
+                "metadata_json": ujson.dumps(
                     {
                         "id": i,
                         "title": title,

--- a/api/tools/populate_qa.py
+++ b/api/tools/populate_qa.py
@@ -3,11 +3,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import codecs
-import json
 import os
 import secrets
 import sys
 
+import ujson
 from models.context import Context
 from models.round import Round, RoundModel
 from models.task import TaskModel
@@ -21,11 +21,11 @@ contexts = {"1": [], "2": []}
 for n in contexts.keys():
     fpath = os.path.join(fname)
     print(fpath)
-    this_contexts = [json.loads(ll) for ll in codecs.open(fpath, "r", "utf8")]
+    this_contexts = [ujson.loads(ll) for ll in codecs.open(fpath, "r", "utf8")]
     this_contexts = [
         {
             "context": c["passage"],
-            "metadata_json": json.dumps(
+            "metadata_json": ujson.dumps(
                 {
                     "id": c["id"],
                     "title": c["title"],

--- a/api/tools/populate_sentiment.py
+++ b/api/tools/populate_sentiment.py
@@ -2,11 +2,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import json
 import sys
 
 import pandas as pd
 
+import ujson
 from models.context import Context
 from models.round import RoundModel
 from models.task import TaskModel
@@ -23,7 +23,7 @@ data = []
 for review_id, sent in zip(contexts["review_id"], contexts["sentence"]):
     print(review_id, sent)
     data.append(
-        {"context": sent, "metadata_json": json.dumps({"review_id": review_id})}
+        {"context": sent, "metadata_json": ujson.dumps({"review_id": review_id})}
     )
 
 tm = TaskModel()

--- a/api/tools/populate_vqa.py
+++ b/api/tools/populate_vqa.py
@@ -4,7 +4,7 @@
 
 # flake8: noqa
 
-import json  # isort:skip
+import ujson  # isort:skip
 import os  # isort:skip
 import sys  # isort:skip
 
@@ -19,7 +19,7 @@ from models.task import TaskModel  # isort:skip
 def getImagesFromFile(fileName):
     path = f"annotations/{fileName}.json"
     with open(path) as jsonFile:
-        anns = json.load(jsonFile)
+        anns = ujson.load(jsonFile)
         return anns["images"]
 
 
@@ -67,7 +67,7 @@ def main():
                 data.append(
                     {
                         "context": url,
-                        "metadata_json": json.dumps(
+                        "metadata_json": ujson.dumps(
                             {"id": image["id"], "file_name": fileName}
                         ),
                     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ git+https://github.com/facebookresearch/dynalab.git
 sentencepiece
 spacy
 textflint
+ujson

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ git+https://github.com/facebookresearch/dynalab.git
 sentencepiece
 spacy
 textflint
-ujson
+ujson>=4.2.0


### PR DESCRIPTION
As per https://github.com/facebookresearch/dynabench/issues/639, replaces the builtin `json` library with `ujson`. Interestingly, support for the `default` argument in `.dumps()` which allows one to massage unserialisable objects into a serialisable form was only added a month ago in the latest release (4.2.0) of `ujson`, so we were pretty lucky.