### PR TITLE
Moving to export round data to s3 and sending emails with download link

### DIFF
--- a/api/templates/uploaded_round_data.txt
+++ b/api/templates/uploaded_round_data.txt
@@ -1,0 +1,7 @@
+You can use the following link to get your exported round data (task name: $task_name, round $rid):
+
+$s3_download
+
+Thanks,
+
+The Dynabench Team

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -418,8 +418,12 @@ export default class ApiService {
     return this.fetch(export_link, {
       method: "GET",
     }).then((res) => {
-      res = new TextEncoder("utf-8").encode(JSON.stringify(res));
-      return download(res, "export.json", "text/json");
+      if (res.type == "download") {
+        const res_data = new TextEncoder("utf-8").encode(
+          JSON.stringify(res.data)
+        );
+        return download(res_data, "export.json", "text/json");
+      }
     });
   }
 


### PR DESCRIPTION
As described in #758, sometimes the downloads on the `rounds` page for a given task fail. This PR changes the download pipeline such that when the user requests a download, the data is exported to s3, and the user is sent an email with the link to the download.

(this is a WIP, there are still a few things to fix)