### PR TITLE
Bugfix: include dependency used in #753 in `package.json`

### DIFF
--- a/frontends/web/package-lock.json
+++ b/frontends/web/package-lock.json
@@ -34,6 +34,7 @@
         "react-player": "^2.6.2",
         "react-powerplug": "^1.0.0",
         "react-router-dom": "^5.2.0",
+        "react-router-hash-link": "^2.4.3",
         "react-scripts": "^4.0.3",
         "react-table": "^7.7.0",
         "react-text-annotate": "^0.3.0",
@@ -20137,6 +20138,18 @@
       "peerDependencies": {
         "prop-types": "^15.0.0",
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-router-hash-link": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
+      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=15",
+        "react-router-dom": ">=4"
       }
     },
     "node_modules/react-scripts": {
@@ -41474,6 +41487,14 @@
             }
           }
         }
+      }
+    },
+    "react-router-hash-link": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-2.4.3.tgz",
+      "integrity": "sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "react-scripts": {

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -29,6 +29,7 @@
     "react-player": "^2.6.2",
     "react-powerplug": "^1.0.0",
     "react-router-dom": "^5.2.0",
+    "react-router-hash-link": "^2.4.3",
     "react-scripts": "^4.0.3",
     "react-table": "^7.7.0",
     "react-text-annotate": "^0.3.0",


### PR DESCRIPTION
tiny fix: #753 uses npm package `react-router-hash-link` but it's not included in `package.json` (and as a corollary doesn't install on `npm install`)