### PR TITLE
Script to take down unpublished models from sagemaker

### DIFF
--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -1,0 +1,106 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This script will take down all unpublished models from sagemaker
+# These models can be redeployed by sending a message to the build server
+import sys
+import traceback
+
+from models.model import DeploymentStatusEnum, ModelModel
+
+
+sys.path.remove("../evaluation")  # noqa
+sys.path.append("../builder")  # noqa
+
+from utils.deployer import ModelDeployer  # # noqa isort:skip
+
+
+def delete_existing_endpoints(model_deployer):
+    # note: this is the exact same as ModelDeployer.delete_existing_endpoints()
+    # but for some reason, adding SortOrder="Ascending" causes the API
+    # call to return no results (TODO: figure out why)
+    endpoint_response = model_deployer.env["sagemaker_client"].list_endpoints(
+        SortBy="Name",
+        MaxResults=100,
+        NameContains=model_deployer.endpoint_name,
+    )
+
+    endpoints = endpoint_response["Endpoints"]
+    for endpoint in endpoints:
+        if endpoint["EndpointName"] == model_deployer.endpoint_name:
+            print(f"- Deleting the endpoint {model_deployer.endpoint_name:}")
+            model_deployer.env["sagemaker_client"].delete_endpoint(
+                EndpointName=model_deployer.endpoint_name
+            )
+
+    # remove sagemaker model
+    model_response = model_deployer.env["sagemaker_client"].list_models(
+        SortBy="Name",
+        MaxResults=100,
+        NameContains=model_deployer.endpoint_name,
+    )
+    sm_models = model_response["Models"]
+    for sm_model in sm_models:
+        if sm_model["ModelName"] == model_deployer.endpoint_name:
+            print(f"- Deleting the model {model_deployer.endpoint_name:}")
+            model_deployer.env["sagemaker_client"].delete_model(
+                ModelName=model_deployer.endpoint_name
+            )
+
+    # remove config
+    config_response = model_deployer.env["sagemaker_client"].list_endpoint_configs(
+        SortBy="Name",
+        MaxResults=100,
+        NameContains=model_deployer.endpoint_name,
+    )
+    endpoint_configs = config_response["EndpointConfigs"]
+    for endpoint_config in endpoint_configs:
+        if endpoint_config["EndpointConfigName"] == model_deployer.endpoint_name:
+            print(f"- Deleting the endpoint config {model_deployer.endpoint_name:}")
+            model_deployer.env["sagemaker_client"].delete_endpoint_config(
+                EndpointConfigName=model_deployer.endpoint_name
+            )
+    try:
+        response = model_deployer.env["ecr_client"].delete_repository(
+            repositoryName=model_deployer.repository_name, force=True
+        )
+        print(f"- Deleting the docker repository {model_deployer.repository_name:}")
+    except model_deployer.env["ecr_client"].exceptions.RepositoryNotFoundException:
+        print(
+            f"""Repository {model_deployer.repository_name} not found.
+            If deploying, this will be created"""
+        )
+    else:
+        if response:
+            print(f"Response from deleting ECR repository {response}")
+
+
+m = ModelModel()
+unpublished_models = m.getByPublishStatus(publish_status=False)
+
+for model in unpublished_models:
+    if model.name == "bertstyleqa":  # TODO: remove this
+        if model.deployment_status == DeploymentStatusEnum.deployed:
+            print(f"Removing model: {model.name} at endpoint {model.endpoint_name}")
+            try:
+                # Take down the model endpoint
+                deployer = ModelDeployer(model)
+
+                # This should delete the:
+                # 1) model endpoint
+                # 2) sagemaker model
+                # 3) endpoint config
+                # 4) ecr repository (docker image)
+                delete_existing_endpoints(deployer)
+
+                # Update the model to have status `taken_down`
+                m.update(model.id, deployment_status=DeploymentStatusEnum.takendown)
+
+                # Note that we keep the model on s3, so that we can
+                # redeploy the model whenever we want
+
+            except Exception as e:
+                print(f"Ran into exception when taking down model {model.name}")
+                print(traceback.format_exc())
+                print(e)

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -25,12 +25,12 @@ def main():
             try:
                 deployer = ModelDeployer(model)
                 deployer.delete_existing_endpoints(
-                    sort_order="Descending", max_results=1
+                    sort_order="Descending", max_results=10
                 )
 
                 # Update the model to have status `taken_down`
                 m.update(
-                    model.id, deployment_status=DeploymentStatusEnum.takendown_nonactive
+                    model.id, deployment_status=DeploymentStatusEnum.takendownnonactive
                 )
 
                 # Note that we keep the model on s3, so that we can

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -80,27 +80,26 @@ m = ModelModel()
 unpublished_models = m.getByPublishStatus(publish_status=False)
 
 for model in unpublished_models:
-    if model.name == "bertstyleqa":  # TODO: remove this
-        if model.deployment_status == DeploymentStatusEnum.deployed:
-            print(f"Removing model: {model.name} at endpoint {model.endpoint_name}")
-            try:
-                # Take down the model endpoint
-                deployer = ModelDeployer(model)
+    if model.deployment_status == DeploymentStatusEnum.deployed:
+        print(f"Removing model: {model.name} at endpoint {model.endpoint_name}")
+        try:
+            # Take down the model endpoint
+            deployer = ModelDeployer(model)
 
-                # This should delete the:
-                # 1) model endpoint
-                # 2) sagemaker model
-                # 3) endpoint config
-                # 4) ecr repository (docker image)
-                delete_existing_endpoints(deployer)
+            # This should delete the:
+            # 1) model endpoint
+            # 2) sagemaker model
+            # 3) endpoint config
+            # 4) ecr repository (docker image)
+            delete_existing_endpoints(deployer)
 
-                # Update the model to have status `taken_down`
-                m.update(model.id, deployment_status=DeploymentStatusEnum.takendown)
+            # Update the model to have status `taken_down`
+            m.update(model.id, deployment_status=DeploymentStatusEnum.takendown)
 
-                # Note that we keep the model on s3, so that we can
-                # redeploy the model whenever we want
+            # Note that we keep the model on s3, so that we can
+            # redeploy the model whenever we want
 
-            except Exception as e:
-                print(f"Ran into exception when taking down model {model.name}")
-                print(traceback.format_exc())
-                print(e)
+        except Exception as e:
+            print(f"Ran into exception when taking down model {model.name}")
+            print(traceback.format_exc())
+            print(e)

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -16,90 +16,31 @@ sys.path.append("../builder")  # noqa
 from utils.deployer import ModelDeployer  # # noqa isort:skip
 
 
-def delete_existing_endpoints(model_deployer):
-    # note: this is the exact same as ModelDeployer.delete_existing_endpoints()
-    # but for some reason, adding SortOrder="Ascending" causes the API
-    # call to return no results (TODO: figure out why)
-    endpoint_response = model_deployer.env["sagemaker_client"].list_endpoints(
-        SortBy="Name",
-        MaxResults=100,
-        NameContains=model_deployer.endpoint_name,
-    )
+def main():
+    m = ModelModel()
+    unpublished_models = m.getByPublishStatus(publish_status=False)
+    for model in unpublished_models:
+        if model.deployment_status == DeploymentStatusEnum.deployed:
+            print(f"Removing model: {model.name} at endpoint {model.endpoint_name}")
+            try:
+                deployer = ModelDeployer(model)
+                deployer.delete_existing_endpoints(
+                    sort_order="Descending", max_results=1
+                )
 
-    endpoints = endpoint_response["Endpoints"]
-    for endpoint in endpoints:
-        if endpoint["EndpointName"] == model_deployer.endpoint_name:
-            print(f"- Deleting the endpoint {model_deployer.endpoint_name:}")
-            model_deployer.env["sagemaker_client"].delete_endpoint(
-                EndpointName=model_deployer.endpoint_name
-            )
+                # Update the model to have status `taken_down`
+                m.update(
+                    model.id, deployment_status=DeploymentStatusEnum.takendown_nonactive
+                )
 
-    # remove sagemaker model
-    model_response = model_deployer.env["sagemaker_client"].list_models(
-        SortBy="Name",
-        MaxResults=100,
-        NameContains=model_deployer.endpoint_name,
-    )
-    sm_models = model_response["Models"]
-    for sm_model in sm_models:
-        if sm_model["ModelName"] == model_deployer.endpoint_name:
-            print(f"- Deleting the model {model_deployer.endpoint_name:}")
-            model_deployer.env["sagemaker_client"].delete_model(
-                ModelName=model_deployer.endpoint_name
-            )
+                # Note that we keep the model on s3, so that we can
+                # redeploy the model whenever we want
 
-    # remove config
-    config_response = model_deployer.env["sagemaker_client"].list_endpoint_configs(
-        SortBy="Name",
-        MaxResults=100,
-        NameContains=model_deployer.endpoint_name,
-    )
-    endpoint_configs = config_response["EndpointConfigs"]
-    for endpoint_config in endpoint_configs:
-        if endpoint_config["EndpointConfigName"] == model_deployer.endpoint_name:
-            print(f"- Deleting the endpoint config {model_deployer.endpoint_name:}")
-            model_deployer.env["sagemaker_client"].delete_endpoint_config(
-                EndpointConfigName=model_deployer.endpoint_name
-            )
-    try:
-        response = model_deployer.env["ecr_client"].delete_repository(
-            repositoryName=model_deployer.repository_name, force=True
-        )
-        print(f"- Deleting the docker repository {model_deployer.repository_name:}")
-    except model_deployer.env["ecr_client"].exceptions.RepositoryNotFoundException:
-        print(
-            f"""Repository {model_deployer.repository_name} not found.
-            If deploying, this will be created"""
-        )
-    else:
-        if response:
-            print(f"Response from deleting ECR repository {response}")
+            except Exception as e:
+                print(f"Ran into exception when taking down model {model.name}")
+                print(traceback.format_exc())
+                print(e)
 
 
-m = ModelModel()
-unpublished_models = m.getByPublishStatus(publish_status=False)
-
-for model in unpublished_models:
-    if model.deployment_status == DeploymentStatusEnum.deployed:
-        print(f"Removing model: {model.name} at endpoint {model.endpoint_name}")
-        try:
-            # Take down the model endpoint
-            deployer = ModelDeployer(model)
-
-            # This should delete the:
-            # 1) model endpoint
-            # 2) sagemaker model
-            # 3) endpoint config
-            # 4) ecr repository (docker image)
-            delete_existing_endpoints(deployer)
-
-            # Update the model to have status `taken_down`
-            m.update(model.id, deployment_status=DeploymentStatusEnum.takendown)
-
-            # Note that we keep the model on s3, so that we can
-            # redeploy the model whenever we want
-
-        except Exception as e:
-            print(f"Ran into exception when taking down model {model.name}")
-            print(traceback.format_exc())
-            print(e)
+if __name__ == "__main__":
+    main()

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -3,7 +3,9 @@
 # LICENSE file in the root directory of this source tree.
 
 # This script will take down all unpublished models from sagemaker
-# These models can be redeployed by sending a message to the build server
+# These models can be redeployed by sending a message to the build
+# server, for example:
+# {"model_id": MODEL_ID, "s3_uri": s3_PATH_TO_SAVED_MODEL}
 import sys
 import traceback
 

--- a/api/migrations/20211028_01_ukEWR-adding-taken-down-non-active-enum.py
+++ b/api/migrations/20211028_01_ukEWR-adding-taken-down-non-active-enum.py
@@ -24,9 +24,10 @@ steps = [
         DEFAULT "unknown"
         """,
         """
-        ALTER TABLE models MODIFY deployment_status
+         ALTER TABLE models MODIFY deployment_status
         ENUM('uploaded', 'processing', 'deployed',
-        'created', 'failed', 'unknown', "takendown")
+        'created', 'failed', 'unknown', "takendown",
+        "predictions_upload")
         DEFAULT "unknown"
         """,
     )

--- a/api/migrations/20211028_01_ukEWR-adding-taken-down-non-active-enum.py
+++ b/api/migrations/20211028_01_ukEWR-adding-taken-down-non-active-enum.py
@@ -1,0 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Adding taken_down_non_active enum
+"""
+
+from yoyo import step
+
+
+__depends__ = {
+    "20211006_01_DeVEP-big-data-changes",
+    "20211010_01_2P6E7-add-is-anonymous-column-to-model",
+}
+
+steps = [
+    step(
+        """
+        ALTER TABLE models MODIFY deployment_status
+        ENUM('uploaded', 'processing', 'deployed',
+        'created', 'failed', 'unknown', "takendown",
+        "predictions_upload", "takendownnonactive")
+        DEFAULT "unknown"
+        """,
+        """
+        ALTER TABLE models MODIFY deployment_status
+        ENUM('uploaded', 'processing', 'deployed',
+        'created', 'failed', 'unknown', "takendown")
+        DEFAULT "unknown"
+        """,
+    )
+]

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -20,6 +20,7 @@ class DeploymentStatusEnum(enum.Enum):
     unknown = "unknown"
     takendown = "takendown"
     predictions_upload = "predictions_upload"
+    takendown_nonactive = "takendownnonactive"
 
 
 class EvaluationStatusEnum(enum.Enum):

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -151,6 +151,9 @@ class ModelModel(BaseModel):
             .all()
         )
 
+    def getByPublishStatus(self, publish_status):
+        return self.dbs.query(Model).filter(Model.is_published == publish_status).all()
+
     def getCountByUidTidAndHrDiff(self, uid, tid=-1, hr_diff=24):
         """
         Returns submissions of all time if hr_diff < 0

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -20,7 +20,7 @@ class DeploymentStatusEnum(enum.Enum):
     unknown = "unknown"
     takendown = "takendown"
     predictions_upload = "predictions_upload"
-    takendown_nonactive = "takendownnonactive"
+    takendownnonactive = "takendownnonactive"
 
 
 class EvaluationStatusEnum(enum.Enum):

--- a/builder/utils/deployer.py
+++ b/builder/utils/deployer.py
@@ -112,12 +112,12 @@ class ModelDeployer:
 
         return env
 
-    def delete_existing_endpoints(self):
+    def delete_existing_endpoints(self, sort_order="Ascending", max_results=100):
         # remove endpoint
         endpoint_response = self.env["sagemaker_client"].list_endpoints(
             SortBy="Name",
-            SortOrder="Ascending",
-            MaxResults=100,
+            SortOrder=sort_order,
+            MaxResults=max_results,
             NameContains=self.endpoint_name,
         )
         endpoints = endpoint_response["Endpoints"]
@@ -131,8 +131,8 @@ class ModelDeployer:
         # remove sagemaker model
         model_response = self.env["sagemaker_client"].list_models(
             SortBy="Name",
-            SortOrder="Ascending",
-            MaxResults=100,
+            SortOrder=sort_order,
+            MaxResults=max_results,
             NameContains=self.endpoint_name,
         )
         sm_models = model_response["Models"]
@@ -144,8 +144,8 @@ class ModelDeployer:
         # remove config
         config_response = self.env["sagemaker_client"].list_endpoint_configs(
             SortBy="Name",
-            SortOrder="Ascending",
-            MaxResults=100,
+            SortOrder=sort_order,
+            MaxResults=max_results,
             NameContains=self.endpoint_name,
         )
         endpoint_configs = config_response["EndpointConfigs"]

--- a/frontends/web/src/containers/ModelStatus.js
+++ b/frontends/web/src/containers/ModelStatus.js
@@ -86,6 +86,10 @@ const DeploymentStatus = ({ deploymentStatus }) => {
       description =
         "The model could not return predictions on all of the datasets. The model could have bugs.";
       break;
+    case "takendownnonactive":
+      buttonVariant = "danger";
+      description = "The model was taken down due to inactivity.";
+      break;
     case "failed":
       buttonVariant = "danger";
       description = "The model could not be deployed.";


### PR DESCRIPTION
As mentioned in issue #797, we cannot have all models constantly active and would rather take down all models that are not published. 

This script does that by looking at all unpublished deployed models, and "takes them down" which we define as:
1) deleting the endpoint
2) deleting the sagemaker model
3) deleting the endpoint config
4) deleting the ECR repository (docker image)