### PR TITLE
Taking down unpublished models with `created` status 

### DIFF
--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -26,7 +26,7 @@ def parse_args():
         "--task_code",
         type=str,
         default="",
-        help=("Task code to filter by when choosing what models to delete "),
+        help=("Task code to filter by when choosing what models to delete."),
     )
     args = parser.parse_args()
 

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -26,7 +26,7 @@ def parse_args():
         "--task_code",
         type=str,
         default="",
-        help=("Task code to filter models by " "when choosing to delete "),
+        help=("Task code to filter by when choosing what models to delete "),
     )
     args = parser.parse_args()
 

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -22,7 +22,10 @@ def main():
     m = ModelModel()
     unpublished_models = m.getByPublishStatus(publish_status=False)
     for model in unpublished_models:
-        if model.deployment_status == DeploymentStatusEnum.deployed:
+        if (
+            model.deployment_status == DeploymentStatusEnum.deployed
+            or model.deployment_status == DeploymentStatusEnum.created
+        ):
             print(f"Removing model: {model.name} at endpoint {model.endpoint_name}")
             try:
                 deployer = ModelDeployer(model)

--- a/api/cron/takedown_unpublished_models.py
+++ b/api/cron/takedown_unpublished_models.py
@@ -26,7 +26,11 @@ def parse_args():
         "--task_code",
         type=str,
         default="",
-        help=("Task code to filter by when choosing what models to delete."),
+        help=(
+            "The script will take down all unpublished model endpoints for every task."
+            "Here, you can additionally specify a task where you want to take down"
+            "all published model endpoints as well."
+        ),
     )
     args = parser.parse_args()
 
@@ -42,7 +46,8 @@ def main():
 
     if args.task_code.strip() != "":
         ops = input(
-            f"Take down all models associated with task code {args.task_code}? [y/n]"
+            f"Take down all model endpoints associated with task code {args.task_code},"
+            "including published models? [y/n]"
         )
         if ops.lower() not in ("y", "yes"):
             print(f"Aborting takedown script")


### PR DESCRIPTION
This PR is related to #803, and does two things:
(1) taking down `created`, unpublished models (instead of just models with `deployed` status
(2) adding an option to take down all models associated with a certain `task_code`