### PR TITLE
Fixing prune_models script to search through all AWS objects to find objects to delete

### DIFF
--- a/api/cron/prune_models.py
+++ b/api/cron/prune_models.py
@@ -33,6 +33,211 @@ from utils.deployer import ModelDeployer  # noqa isort:skip
 from build_config import build_config  # noqa isort:skip
 
 
+class ModelPruner:
+    def __init__(
+        self, region, endpoint_last_used_cutoff, test_run, endpoints_name_not_touch
+    ):
+        self.region = region
+        self.endpoint_last_used_cutoff = endpoint_last_used_cutoff
+        self.test_run = test_run
+        self.endpoints_name_not_touch = endpoints_name_not_touch
+
+        # Setup AWS session
+        session = boto3.Session(
+            aws_access_key_id=build_config["aws_access_key_id"],
+            aws_secret_access_key=build_config["aws_secret_access_key"],
+            region_name=region,
+        )
+
+        self.sm = session.client("sagemaker")
+        self.cw = session.client("cloudwatch")
+
+        self.obj_type_to_sm_method = {
+            "endpoint": self.sm.list_endpoints,
+            "sagemaker_model": self.sm.list_models,
+            "endpoint_config": self.sm.list_endpoint_configs,
+        }
+
+        self.obj_type_to_sm_resp_field = {
+            "endpoint": "Endpoints",
+            "sagemaker_model": "Models",
+            "endpoint_config": "EndpointConfigs",
+        }
+
+        self.endpoints_deleted = []
+
+    def _dont_touch_endpoint(self, ep_name):
+        return len(self.endpoints_name_not_touch) > 0 and (
+            any(
+                ep_name in bad_endpoint
+                for bad_endpoint in self.endpoints_name_not_touch
+            )
+        )
+
+    def _delete_from_aws(self, endpoint_name):
+        print(f"Removing model endpoint at: {endpoint_name}")
+
+        # Delete Endpoint
+        endpoint_to_delete = self._find_obj(endpoint_name, "endpoint")
+        if endpoint_to_delete is not None:
+            self.sm.delete_endpoint(EndpointName=endpoint_name)
+
+        # Delete Sagemaker model
+        model_to_delete = self._find_obj(endpoint_name, "sagemaker_model")
+        if model_to_delete is not None:
+            self.sm.delete_model(ModelName=endpoint_name)
+
+        # Delete Endpoint Config
+        endpoint_config_to_delete = self._find_obj(endpoint_name, "endpoint_config")
+        if endpoint_config_to_delete is not None:
+            self.sm.delete_endpoint_config(EndpointConfigName=endpoint_name)
+
+    def _find_obj(self, ep_name, obj_name):
+        sm_method = self.obj_type_to_sm_method[obj_name]
+        sm_resp_field = self.obj_type_to_sm_resp_field[obj_name]
+
+        endpoint_response = sm_method(
+            NameContains=ep_name,
+            MaxResults=100,
+        )
+
+        endpoints = endpoint_response[sm_resp_field]
+        while "NextToken" in endpoint_response:
+            next_token = endpoint_response["NextToken"]
+            endpoint_response = sm_method(
+                NameContains=ep_name,
+                MaxResults=100,
+                NextToken=next_token,
+            )
+
+            endpoints += endpoint_response[sm_resp_field]
+
+        if len(endpoints) < 1:
+            print(f"Found no AWS object of type {obj_name} for {ep_name}, skipping...")
+            return
+
+        if len(endpoints) > 1:
+            print(
+                f"Found multiple AWS objects of type {obj_name} for {ep_name}"
+                ", skipping..."
+            )
+            return
+
+        return endpoints[0]
+
+    def delete_models_not_in_the_loop(self):
+        m = ModelModel()
+        models_not_in_loop = m.getByInTheLoopStatus(in_the_loop=False)
+        for model in models_not_in_loop:
+            if (
+                model.deployment_status == DeploymentStatusEnum.deployed
+                or model.deployment_status == DeploymentStatusEnum.created
+            ):
+
+                try:
+                    # Check if the endpoint has been used in the last hour
+                    ep_to_analyze = self._find_obj(model.endpoint_name, "endpoint")
+
+                    if ep_to_analyze is None:
+                        continue
+
+                    ep_describe = self.sm.describe_endpoint(
+                        EndpointName=ep_to_analyze["EndpointName"]
+                    )
+
+                    metric_response = self.cw.get_metric_statistics(
+                        Namespace="AWS/SageMaker",
+                        MetricName="Invocations",
+                        Dimensions=[
+                            {
+                                "Name": "EndpointName",
+                                "Value": ep_to_analyze["EndpointName"],
+                            },
+                            {
+                                "Name": "VariantName",
+                                "Value": ep_describe["ProductionVariants"][0][
+                                    "VariantName"
+                                ],
+                            },
+                        ],
+                        StartTime=datetime.utcnow()
+                        - timedelta(hours=self.endpoint_last_used_cutoff),
+                        EndTime=datetime.utcnow(),
+                        Period=int(self.endpoint_last_used_cutoff * 60 * 60),
+                        Statistics=["Sum"],
+                        Unit="None",
+                    )
+
+                    if (
+                        len(metric_response["Datapoints"]) <= 0
+                        or metric_response["Datapoints"][0]["Sum"] <= 0.0
+                    ):
+
+                        if self._dont_touch_endpoint(model.endpoint_name):
+                            continue
+
+                        self.endpoints_deleted.append(model.endpoint_name)
+                        if self.test_run:
+                            continue
+
+                        self._delete_from_aws(model.endpoint_name)
+
+                        # Update status to show that model endpoint was deleted
+                        m.update(
+                            model.id,
+                            deployment_status=DeploymentStatusEnum.takendownnonactive,
+                        )
+
+                except Exception as e:
+                    print(f"Ran into exception when analyzing model {model.name}")
+                    print(traceback.format_exc())
+                    print(e)
+
+    def delete_non_prod_model_endpoints(self):
+        m = ModelModel()
+        endpoint_response = self.sm.list_endpoints(
+            SortBy="Name",
+            MaxResults=100,
+        )
+
+        endpoints = endpoint_response["Endpoints"]
+        while "NextToken" in endpoint_response:
+            next_token = endpoint_response["NextToken"]
+            endpoint_response = self.sm.list_endpoints(
+                SortBy="Name", MaxResults=100, NextToken=next_token
+            )
+
+            endpoints += endpoint_response["Endpoints"]
+
+        for ep in endpoints:
+
+            try:
+                ep_name = ep["EndpointName"]
+
+                models_with_endpoint_name = m.getByEndpointName(endpoint_name=ep_name)
+
+                # If the endpoints do not correspond to any model in the DB
+                if len(models_with_endpoint_name) < 1:
+
+                    if self._dont_touch_endpoint(ep_name):
+                        continue
+
+                    self.endpoints_deleted.append(ep_name)
+                    if self.test_run:
+                        continue
+
+                    self._delete_from_aws(ep_name)
+
+                    # We don't update any model status here,
+                    # because by definition there is no
+                    # model in the DB to associate with this endpoint
+
+            except Exception as e:
+                print(f"Ran into exception when deleting endpoint {ep_name}")
+                print(traceback.format_exc())
+                print(e)
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -64,37 +269,6 @@ def parse_args():
     return args
 
 
-def dont_touch_endpoint(endpoints_name_not_touch, ep_name):
-    return len(endpoints_name_not_touch) > 0 and (
-        any(ep_name in bad_endpoint for bad_endpoint in endpoints_name_not_touch)
-    )
-
-
-def delete_endpoint(sagemaker_client, endpoint_name):
-    print(f"Removing model endpoint at: {endpoint_name}")
-
-    # Delete endpoint
-    sagemaker_client.delete_endpoint(EndpointName=endpoint_name)
-
-    # Delete Sagemaker model
-    model_response = sagemaker_client.list_models(
-        SortBy="Name",
-        NameContains=endpoint_name,
-    )
-
-    if len(model_response["Models"]) == 1:
-        sagemaker_client.delete_model(ModelName=endpoint_name)
-
-    # Delete Endpoint Config
-    config_response = sagemaker_client.list_endpoint_configs(
-        SortBy="Name",
-        NameContains=endpoint_name,
-    )
-
-    if len(config_response["EndpointConfigs"]) == 1:
-        sagemaker_client.delete_endpoint_config(EndpointConfigName=endpoint_name)
-
-
 def main():
     args = parse_args()
 
@@ -123,141 +297,18 @@ def main():
         print(f"Aborting takedown script")
         exit(1)
 
-    session = boto3.Session(
-        aws_access_key_id=build_config["aws_access_key_id"],
-        aws_secret_access_key=build_config["aws_secret_access_key"],
-        region_name=args.region,
+    model_pruner = ModelPruner(
+        args.region,
+        args.endpoint_last_used_cutoff,
+        args.test_run,
+        endpoints_name_not_touch,
     )
-
-    sm = session.client("sagemaker")
-    cw = session.client("cloudwatch")
-    endpoint_last_used_cutoff = args.endpoint_last_used_cutoff
-    endpoints_deleted = []
-
-    m = ModelModel()
-
-    # Get all non in-the-loop models
-    models_not_in_loop = m.getByInTheLoopStatus(in_the_loop=False)
-
-    for model in models_not_in_loop:
-        if (
-            model.deployment_status == DeploymentStatusEnum.deployed
-            or model.deployment_status == DeploymentStatusEnum.created
-        ):
-            try:
-                # Check if the endpoint has been used in the last hour
-                endpoint_response = sm.list_endpoints(
-                    SortBy="Name",
-                    SortOrder="Descending",
-                    MaxResults=10,
-                    NameContains=model.endpoint_name,
-                    StatusEquals="InService",
-                )
-
-                if len(endpoint_response["Endpoints"]) != 1:
-                    print(
-                        "Error! Should be considering exactly one endpoint for a model"
-                    )
-                    print(
-                        f"Skipping model: {model.name} at"
-                        f"endpoint {model.endpoint_name}"
-                    )
-                    continue
-
-                ep_to_analyze = endpoint_response["Endpoints"][0]
-
-                ep_describe = sm.describe_endpoint(
-                    EndpointName=ep_to_analyze["EndpointName"]
-                )
-
-                metric_response = cw.get_metric_statistics(
-                    Namespace="AWS/SageMaker",
-                    MetricName="Invocations",
-                    Dimensions=[
-                        {
-                            "Name": "EndpointName",
-                            "Value": ep_to_analyze["EndpointName"],
-                        },
-                        {
-                            "Name": "VariantName",
-                            "Value": ep_describe["ProductionVariants"][0][
-                                "VariantName"
-                            ],
-                        },
-                    ],
-                    StartTime=datetime.utcnow()
-                    - timedelta(hours=endpoint_last_used_cutoff),
-                    EndTime=datetime.utcnow(),
-                    Period=int(endpoint_last_used_cutoff * 60 * 60),
-                    Statistics=["Sum"],
-                    Unit="None",
-                )
-
-                if (
-                    len(metric_response["Datapoints"]) <= 0
-                    or metric_response["Datapoints"][0]["Sum"] <= 0.0
-                ):
-
-                    if dont_touch_endpoint(
-                        endpoints_name_not_touch, model.endpoint_name
-                    ):
-                        continue
-
-                    endpoints_deleted.append(model.endpoint_name)
-                    if args.test_run:
-                        continue
-
-                    delete_endpoint(sm, model.endpoint_name)
-
-                    # Update status to show that model endpoint was deleted
-                    m.update(
-                        model.id,
-                        deployment_status=DeploymentStatusEnum.takendownnonactive,
-                    )
-
-            except Exception as e:
-                print(f"Ran into exception when analyzing model {model.name}")
-                print(traceback.format_exc())
-                print(e)
-
-    # Get all endpoints not associated with any model
-    endpoint_response = sm.list_endpoints(
-        SortBy="Name",
-        SortOrder="Descending",
-        MaxResults=100,
-    )
-
-    endpoints = endpoint_response["Endpoints"]
-    while "NextToken" in endpoint_response:
-        next_token = endpoint_response["NextToken"]
-        endpoint_response = sm.list_endpoints(
-            SortBy="Name", SortOrder="Descending", MaxResults=100, NextToken=next_token
-        )
-
-        endpoints += endpoint_response["Endpoints"]
-
-    for ep in endpoints:
-        ep_name = ep["EndpointName"]
-
-        models_with_endpoint_name = m.getByEndpointName(endpoint_name=ep_name)
-
-        # If the endpoints do not correspond to any model in the DB
-        if len(models_with_endpoint_name) < 1:
-
-            if dont_touch_endpoint(endpoints_name_not_touch, ep_name):
-                continue
-
-            endpoints_deleted.append(ep_name)
-            if args.test_run:
-                continue
-            delete_endpoint(sm, ep_name)
-
-            # We don't update any model status here, because by definition there is no
-            # model in the DB to associate with this endpoint
+    model_pruner.delete_models_not_in_the_loop()
+    model_pruner.delete_non_prod_model_endpoints()
 
     print("Endpoints deleted:")
-    print(endpoints_deleted)
-    print(f"# Endpoints deleted is: {len(endpoints_deleted)}")
+    print(model_pruner.endpoints_deleted)
+    print(f"# Endpoints deleted is: {len(model_pruner.endpoints_deleted)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The old version of `prune_models.py` failed to delete a lot of models it should have, because it could not find AWS objects (endpoints, sagemaker models, endpoint configs) with given names. This is because we did not use the `nextToken` part of the API to search through all AWS objects (the `nameContains` request parameter is only a filter)