### PR TITLE
validate dataset names

### DIFF
--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -87,11 +87,11 @@ def delete(credentials, did):
 def create(credentials, tid, name):
     ensure_owner_or_admin(tid, credentials["id"])
 
-    if not bool(re.fullmatch("[a-zA-Z0-9]{1,13}", name)):
+    if not bool(re.fullmatch("[a-zA-Z0-9]{1,62}", name)):
         bottle.abort(
             400,
             "Invalid dataset name - must be purely alphanumeric "
-            + "and have 13 characters or less",
+            + "and shorter than 63 characters",
         )
 
     dataset_upload = bottle.request.files.get("file")

--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -87,15 +87,14 @@ def delete(credentials, did):
 def create(credentials, tid, name):
     ensure_owner_or_admin(tid, credentials["id"])
 
-    if len(name) > 27 or not bool(re.search("^[a-zA-Z0-9_-]*$", name)):
+    if not bool(re.fullmatch("[a-zA-Z0-9]{1,62}", name)):
         bottle.abort(
             400,
-            "Invalid name (no special characters allowed besides underscores "
-            + "and dashes, must be shorter than 28 characters)",
+            "Invalid dataset name - (must be purely alphanumeric "
+            + "and shorter than 63 characters)",
         )
 
     dataset_upload = bottle.request.files.get("file")
-
     tm = TaskModel()
     task = tm.get(tid)
 

--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -87,11 +87,11 @@ def delete(credentials, did):
 def create(credentials, tid, name):
     ensure_owner_or_admin(tid, credentials["id"])
 
-    if not bool(re.fullmatch("[a-zA-Z0-9]{1,62}", name)):
+    if not bool(re.fullmatch("[a-zA-Z0-9]{1,13}", name)):
         bottle.abort(
             400,
             "Invalid dataset name - must be purely alphanumeric "
-            + "and shorter than 63 characters",
+            + "and have 13 characters or less",
         )
 
     dataset_upload = bottle.request.files.get("file")

--- a/api/controllers/datasets.py
+++ b/api/controllers/datasets.py
@@ -90,11 +90,12 @@ def create(credentials, tid, name):
     if not bool(re.fullmatch("[a-zA-Z0-9]{1,62}", name)):
         bottle.abort(
             400,
-            "Invalid dataset name - (must be purely alphanumeric "
-            + "and shorter than 63 characters)",
+            "Invalid dataset name - must be purely alphanumeric "
+            + "and shorter than 63 characters",
         )
 
     dataset_upload = bottle.request.files.get("file")
+
     tm = TaskModel()
     task = tm.get(tid)
 

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -119,7 +119,7 @@ const Datasets = (props) => {
                           <Form.Control
                             value={values.name}
                             onChange={handleChange}
-                            placeholder="[a-zA-Z0-9]{1,62}"
+                            placeholder="[a-zA-Z0-9]{1,13}"
                           />
                         </Col>
                       </Form.Group>

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -119,6 +119,7 @@ const Datasets = (props) => {
                           <Form.Control
                             value={values.name}
                             onChange={handleChange}
+                            placeholder="[a-zA-Z0-9]{1,62}"
                           />
                         </Col>
                       </Form.Group>

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -149,7 +149,7 @@ const Datasets = (props) => {
                         </Form.Group>
                       ))}
                       <Form.Group as={Row} className="py-3 my-0">
-                        <Col sm="8">
+                        <Col sm="12">
                           <small className="form-text text-muted">
                             {errors.accept}
                           </small>

--- a/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Datasets.js
@@ -119,7 +119,7 @@ const Datasets = (props) => {
                           <Form.Control
                             value={values.name}
                             onChange={handleChange}
-                            placeholder="[a-zA-Z0-9]{1,13}"
+                            placeholder="[a-zA-Z0-9]{1,62}"
                           />
                         </Col>
                       </Form.Group>


### PR DESCRIPTION
As per part 1 of https://github.com/facebookresearch/dynabench/issues/835, implements the more accurate regex for name validation on the backend. also adds a hint on the frontend input field that shows the regex.

the new regex demands the name is alphanumeric and be {1,62} chars, as identified by @TristanThrush in https://github.com/facebookresearch/dynabench/issues/835#issuecomment-984339524 (i took the liberty to deny 0-char names, is there a reason to accept them?)

quick question - does this 62-char limit take into account the **perturbation prefixes** that will be added to the datasets? (in the first place, are perturbed datasets sent to the eval server with their name and perturbation prefix?) if so, char limit should be 62-11=51 (`robustness-`)