### PR TITLE
Fixing the potential query_dict["annotator_id"] = None issue in GET /examples/<tid:int>/<rid:int>

### DIFF
--- a/api/controllers/examples.py
+++ b/api/controllers/examples.py
@@ -81,13 +81,20 @@ def get_random_example(credentials, tid, rid):
             tags=tags,
         )
     else:
+        curr_uid = None
+
+        if "annotator_id" in query_dict and isinstance(
+            query_dict["annotator_id"], list
+        ):
+            curr_uid = query_dict["annotator_id"][0]
+
         example = em.getRandom(
             round.id,
             task.validate_non_fooling,
             task.num_matching_validations,
             n=1,
             tags=tags,
-            my_uid=query_dict["annotator_id"][0],
+            my_uid=curr_uid,
             turk=True,
         )
     if not example:


### PR DESCRIPTION
As per #821, this is a quick fix to ensure the endpoint does not break if the `query_dict` does not contain an `annotator_id` on line https://github.com/facebookresearch/dynabench/blob/main/api/controllers/examples.py#L90