### PR TITLE
redid evaluation status to be dataset-specific

### DIFF
--- a/api/migrations/20211220_01_I8aZI-redo-evaluation-status.py
+++ b/api/migrations/20211220_01_I8aZI-redo-evaluation-status.py
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Redo evaluation_status to be specific to datasets.
+"""
+
+from yoyo import step
+
+
+__depends__ = {
+    "20211026_01_scyfj-support-dataperf",
+    "20211103_01_pdUwN-add-placeholder-validation",
+}
+
+steps = [
+    step(
+        "ALTER TABLE models DROP evaluation_status",
+        """
+        ALTER TABLE models ADD COLUMN evaluation_status
+        ENUM('evaluating', 'completed', 'failed', 'pre_evaluation')
+        DEFAULT "pre_evaluation"
+        """,
+    ),
+    step(
+        """
+        ALTER TABLE models ADD COLUMN evaluation_status_json TEXT
+        """,
+        "ALTER TABLE models DROP evaluation_status_json",
+    ),
+]

--- a/api/models/model.py
+++ b/api/models/model.py
@@ -24,13 +24,6 @@ class DeploymentStatusEnum(enum.Enum):
     takendownnonactive = "takendownnonactive"
 
 
-class EvaluationStatusEnum(enum.Enum):
-    evaluating = "evaluating"
-    completed = "completed"
-    pre_evaluation = "pre_evaluation"
-    failed = "failed"
-
-
 class Model(Base):
     __tablename__ = "models"
     __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_general_ci"}
@@ -48,6 +41,9 @@ class Model(Base):
     longdesc = db.Column(db.Text)
     papers = db.Column(db.Text)
 
+    # Dataset eval info
+    evaluation_status_json = db.Column(db.Text)
+
     # Model cards
     params = db.Column(db.BigInteger)
     languages = db.Column(db.Text)
@@ -63,9 +59,6 @@ class Model(Base):
     endpoint_name = db.Column(db.Text)
     deployment_status = db.Column(
         db.Enum(DeploymentStatusEnum), default=DeploymentStatusEnum.unknown
-    )
-    evaluation_status = db.Column(
-        db.Enum(EvaluationStatusEnum), default=EvaluationStatusEnum.pre_evaluation
     )
 
     secret = db.Column(db.Text)

--- a/evaluation/metrics/metrics.py
+++ b/evaluation/metrics/metrics.py
@@ -157,7 +157,7 @@ def get_vqa_accuracy_meta(task=None):
 
 def get_macro_f1(predictions: list, targets: list):
     macro_f1 = f1_score(targets, predictions, average="macro")
-    return round(macro_f1 * 100, 2)
+    return round(float(macro_f1) * 100, 2)
 
 
 def get_macro_f1_meta(task=None):

--- a/evaluation/utils/helpers.py
+++ b/evaluation/utils/helpers.py
@@ -10,6 +10,22 @@ from typing import List
 
 import boto3
 
+from models.model import ModelModel
+
+
+def update_evaluation_status(mid, dataset_name, evaluation_status):
+    mm = ModelModel()
+    model = mm.get(mid)
+    if model.evaluation_status_json:
+        eval_statuses = json.loads(model.evaluation_status_json)
+    else:
+        eval_statuses = {}
+    eval_statuses[dataset_name] = evaluation_status
+    model.evaluation_status_json = json.dumps(eval_statuses)
+    mm.dbs.add(model)
+    mm.dbs.flush()
+    mm.dbs.commit()
+
 
 def get_predictions_s3_path(endpoint_name, task_code, dataset_name):
     return os.path.join(

--- a/frontends/web/src/containers/ModelPage.js
+++ b/frontends/web/src/containers/ModelPage.js
@@ -35,6 +35,49 @@ import FloresGrid from "../components/FloresComponents/FloresGrid";
 import ChevronExpandButton from "../components/Buttons/ChevronExpandButton";
 import { FLORES_TASK_CODES } from "./FloresTaskPage";
 
+const EvalStatusRow = ({ status }) => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <Table hover className="mb-0 hover" style={{ tableLayout: "fixed" }}>
+      <tbody>
+        <Modal show={showModal} onHide={() => setShowModal(!showModal)}>
+          <Modal.Header closeButton>
+            <Modal.Title>{status.dataset_name}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            {status.dataset_longdesc}
+            <br />
+            <br />
+            {status.dataset_source_url && status.dataset_source_url !== "" ? (
+              <Button href={status.dataset_source_url}>
+                <i className="fas fa-newspaper"></i> Read Paper
+              </Button>
+            ) : (
+              ""
+            )}
+          </Modal.Body>
+        </Modal>
+        <tr key={status.dataset_name}>
+          <td>
+            <span
+              onClick={() => setShowModal(!showModal)}
+              className="btn-link dataset-link"
+            >
+              {status.dataset_name}
+            </span>{" "}
+          </td>
+          <td className="text-right t-2" key={`status-${status.dataset_name}`}>
+            <span>
+              <EvaluationStatus evaluationStatus={status.evaluation_status} />
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+};
+
 const ScoreRow = ({ score }) => {
   const [expanded, setExpanded] = useState(false);
   const [showModal, setShowModal] = useState(false);
@@ -389,6 +432,9 @@ ${latexTableContent}
       parseInt(this.state.model.uid) === parseInt(this.state.ctxUserId);
     const { leaderboard_scores } = this.state.model;
     const { non_leaderboard_scores } = this.state.model;
+    const { leaderboard_evaluation_statuses } = this.state.model;
+    const { non_leaderboard_evaluation_statuses } = this.state.model;
+    const { hidden_evaluation_statuses } = this.state.model;
     let orderedLeaderboardScores = (leaderboard_scores || []).sort(
       (a, b) => a.round_id - b.round_id
     );
@@ -534,14 +580,6 @@ ${latexTableContent}
                           </td>
                         </tr>
                         <tr style={{ border: `none` }}>
-                          <td>Evaluation Status</td>
-                          <td>
-                            <EvaluationStatus
-                              evaluationStatus={model.evaluation_status}
-                            />
-                          </td>
-                        </tr>
-                        <tr style={{ border: `none` }}>
                           <td>Owner</td>
                           <td>
                             {model.uid ? (
@@ -598,44 +636,85 @@ ${latexTableContent}
                         </tr>
                       </tbody>
                     </Table>
-                    <span className={"w-100 mt-5 mx-4"}>
-                      <DropdownButton
-                        alignRight={true}
-                        variant="outline-primary"
-                        className="mr-2 float-right"
-                        title={"Export"}
-                      >
-                        <Dropdown.Item onClick={this.downloadCsv}>
-                          {"CSV"}
-                        </Dropdown.Item>
-                        <Dropdown.Item onClick={this.downloadLatex}>
-                          {"LaTeX"}
-                        </Dropdown.Item>
-                      </DropdownButton>
-                    </span>
-                    <Table>
-                      <tbody>
-                        <tr>
-                          <td colSpan={2}>
-                            <h5>Leaderboard Datasets</h5>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </Table>
+                    {orderedLeaderboardScores.length > 0 ||
+                    orderedNonLeaderboardScores.length ? (
+                      <span className={"w-100 mt-5 mx-4"}>
+                        <DropdownButton
+                          alignRight={true}
+                          variant="outline-primary"
+                          className="mr-2 float-right"
+                          title={"Export"}
+                        >
+                          <Dropdown.Item onClick={this.downloadCsv}>
+                            {"CSV"}
+                          </Dropdown.Item>
+                          <Dropdown.Item onClick={this.downloadLatex}>
+                            {"LaTeX"}
+                          </Dropdown.Item>
+                        </DropdownButton>
+                      </span>
+                    ) : (
+                      ""
+                    )}
+                    {orderedLeaderboardScores.length > 0 ||
+                    leaderboard_evaluation_statuses.length ? (
+                      <Table>
+                        <tbody>
+                          <tr>
+                            <td colSpan={2}>
+                              <h5>Leaderboard Datasets</h5>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </Table>
+                    ) : (
+                      ""
+                    )}
                     {orderedLeaderboardScores.map((score, index) => (
                       <ScoreRow key={index} score={score} />
                     ))}
-                    <Table>
-                      <tbody>
-                        <tr>
-                          <td colSpan={2}>
-                            <h5>Non-Leaderboard Datasets</h5>
-                          </td>
-                        </tr>
-                      </tbody>
-                    </Table>
+                    {leaderboard_evaluation_statuses.map((status, index) => (
+                      <EvalStatusRow key={index} status={status} />
+                    ))}
+                    {orderedNonLeaderboardScores.length > 0 ||
+                    non_leaderboard_evaluation_statuses.length ? (
+                      <Table>
+                        <tbody>
+                          <tr>
+                            <td colSpan={2}>
+                              <h5>Non-Leaderboard Datasets</h5>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </Table>
+                    ) : (
+                      ""
+                    )}
                     {orderedNonLeaderboardScores.map((score, index) => (
                       <ScoreRow score={score} key={index} />
+                    ))}
+                    {non_leaderboard_evaluation_statuses.map(
+                      (status, index) => (
+                        <EvalStatusRow key={index} status={status} />
+                      )
+                    )}
+                    {hidden_evaluation_statuses.length ? (
+                      <Table>
+                        <tbody>
+                          <tr>
+                            <td colSpan={2}>
+                              <h5>
+                                Hidden Dataset Incomplete Evaluation Statuses
+                              </h5>
+                            </td>
+                          </tr>
+                        </tbody>
+                      </Table>
+                    ) : (
+                      ""
+                    )}
+                    {hidden_evaluation_statuses.map((status, index) => (
+                      <EvalStatusRow key={index} status={status} />
                     ))}
                   </InputGroup>
                 ) : (

--- a/frontends/web/src/containers/ModelStatus.js
+++ b/frontends/web/src/containers/ModelStatus.js
@@ -30,11 +30,11 @@ const EvaluationStatus = ({ evaluationStatus }) => {
       break;
     case "failed":
       buttonVariant = "danger";
-      description = "Metrics could not be computed on one or more datasets.";
+      description = "Metrics could not be computed on this dataset.";
       break;
     default:
       buttonVariant = "warning";
-      description = "The evaluation status of the model is unknown.";
+      description = "The evaluation status of this dataset is unknown.";
   }
   return (
     <>


### PR DESCRIPTION
Currently, the evaluation status of models is buggy (completed is shown when not all datasets have been completed) and it is unclear which datasets have failed during evaluation. This pr adds evaluation status for each dataset on a model card, and removes the opaque overall model evaluation status. We might need to modify some of your decentralized PR code to mirror this change @ktirumalafb.