### PR TITLE
enabled overflow in create interface

### DIFF
--- a/frontends/web/src/common/Annotation/CreateInterface.js
+++ b/frontends/web/src/common/Annotation/CreateInterface.js
@@ -761,7 +761,7 @@ class CreateInterface extends React.Component {
                 </div>
               )}
             </div>
-            <Card className="profile-card overflow-hidden">
+            <Card className="profile-card">
               {this.state.loading ? (
                 <div className="mx-auto my-3">
                   <Spinner animation="border" />{" "}


### PR DESCRIPTION
Previously, multilabel dropdown in dataperf was getting truncated.