### PR TITLE
improved usability of no-context tasks

### DIFF
--- a/frontends/web/src/common/Annotation/CreateInterface.js
+++ b/frontends/web/src/common/Annotation/CreateInterface.js
@@ -829,24 +829,28 @@ class CreateInterface extends React.Component {
                       </Col>
                       <Col xs={6}>
                         <InputGroup className="d-flex justify-content-end">
-                          <OverlayTrigger
-                            placement="bottom"
-                            delay={{ show: 250, hide: 400 }}
-                            overlay={renderSwitchContextTooltip}
-                          >
-                            <Annotation
-                              placement="left"
-                              tooltip="Don’t like this context? Try another one."
-                            >
-                              <Button
-                                className="font-weight-bold blue-color light-gray-bg border-0 task-action-btn"
-                                onClick={this.getNewContext}
-                                disabled={this.state.refreshDisabled}
+                          {this.state.annotationConfig &&
+                            this.state.annotationConfig.context.length !==
+                              0 && (
+                              <OverlayTrigger
+                                placement="bottom"
+                                delay={{ show: 250, hide: 400 }}
+                                overlay={renderSwitchContextTooltip}
                               >
-                                Switch to next context
-                              </Button>
-                            </Annotation>
-                          </OverlayTrigger>
+                                <Annotation
+                                  placement="left"
+                                  tooltip="Don’t like this context? Try another one."
+                                >
+                                  <Button
+                                    className="font-weight-bold blue-color light-gray-bg border-0 task-action-btn"
+                                    onClick={this.getNewContext}
+                                    disabled={this.state.refreshDisabled}
+                                  >
+                                    Switch to next context
+                                  </Button>
+                                </Annotation>
+                              </OverlayTrigger>
+                            )}
                           <Annotation
                             placement="top"
                             tooltip="When you’re done, you can submit the example and we’ll find out what the model thinks!"

--- a/frontends/web/src/components/TaskOwnerPageComponents/Rounds.js
+++ b/frontends/web/src/components/TaskOwnerPageComponents/Rounds.js
@@ -224,29 +224,34 @@ const Rounds = (props) => {
                               </Form.Group>
                             </Container>
                           ) : null}
-                          <Form.Group
-                            as={Row}
-                            className="py-3 my-0 border-top"
-                            onClick={() =>
-                              setShowContextUploadRound(
-                                showContextUploadRound.map((obj, rid) =>
-                                  rid === round.rid - 1
-                                    ? !showContextUploadRound[round.rid - 1]
-                                    : obj
+                          {JSON.parse(props.task.annotation_config_json).context
+                            .length !== 0 && (
+                            <Form.Group
+                              as={Row}
+                              className="py-3 my-0 border-top"
+                              onClick={() =>
+                                setShowContextUploadRound(
+                                  showContextUploadRound.map((obj, rid) =>
+                                    rid === round.rid - 1
+                                      ? !showContextUploadRound[round.rid - 1]
+                                      : obj
+                                  )
                                 )
-                              )
-                            }
-                          >
-                            <Form.Label column>Upload Contexts</Form.Label>
-                            <Col sm="8">
-                              <ChevronExpandButton
-                                expanded={showContextUploadRound[round.rid - 1]}
-                                containerClassName={
-                                  "py-2 position-absolute start-100"
-                                }
-                              />
-                            </Col>
-                          </Form.Group>
+                              }
+                            >
+                              <Form.Label column>Upload Contexts</Form.Label>
+                              <Col sm="8">
+                                <ChevronExpandButton
+                                  expanded={
+                                    showContextUploadRound[round.rid - 1]
+                                  }
+                                  containerClassName={
+                                    "py-2 position-absolute start-100"
+                                  }
+                                />
+                              </Col>
+                            </Form.Group>
+                          )}
                           {showContextUploadRound[round.rid - 1] ? (
                             <Contexts
                               values={values}

--- a/frontends/web/src/containers/TaskOwnerPage.js
+++ b/frontends/web/src/containers/TaskOwnerPage.js
@@ -526,6 +526,7 @@ class TaskOwnerPage extends React.Component {
                 this.state.model_identifiers_for_target_selection ? (
                   <Rounds
                     rounds={this.state.rounds}
+                    task={this.state.task}
                     model_identifiers_for_target_selection={
                       this.state.model_identifiers_for_target_selection
                     }


### PR DESCRIPTION
Previously, task owners had to upload empty contexts to initialize their task, even if it was a no-context task. This pr fixes that. This PR also removes some buttons that are unnecessary when there is no context.