### PR TITLE
making `admin_or_owner` turk friendly endpoint

### DIFF
--- a/api/common/cors.py
+++ b/api/common/cors.py
@@ -17,6 +17,7 @@ import bottle
 @bottle.route("/examples/<eid:int>", method="OPTIONS")
 @bottle.route("/examples", method="OPTIONS")
 @bottle.route("/tasks/<task_id_or_code>", method="OPTIONS")
+@bottle.route("/tasks/admin_or_owner/<tid:int>", method="OPTIONS")
 @bottle.route("/validations/<eid:int>", method="OPTIONS")
 def turk_preflight(**args):
     bottle.default_app()

--- a/api/controllers/tasks.py
+++ b/api/controllers/tasks.py
@@ -237,8 +237,12 @@ def get_datasets(credentials, tid):
 
 
 @bottle.get("/tasks/admin_or_owner/<tid:int>")
-@_auth.requires_auth
+@_auth.requires_auth_or_turk
+@_auth.turk_endpoint
 def get_admin_or_owner(credentials, tid):
+    if credentials["id"] == "turk":
+        return util.json_encode({"admin_or_owner": False})
+
     um = UserModel()
     user = um.get(credentials["id"])
     admin_or_owner = True

--- a/frontends/web/src/common/ApiService.js
+++ b/frontends/web/src/common/ApiService.js
@@ -471,9 +471,14 @@ export default class ApiService {
   }
 
   getAdminOrOwner(tid) {
-    return this.fetch(`${this.domain}/tasks/admin_or_owner/${tid}`, {
-      method: "GET",
-    });
+    const includeCredentials = this.mode !== "mturk";
+    return this.doFetch(
+      `${this.domain}/tasks/admin_or_owner/${tid}`,
+      {
+        method: "GET",
+      },
+      includeCredentials
+    );
   }
 
   setExampleMetadata(id, metadata) {


### PR DESCRIPTION
Note to self, to make any endpoint turk friendly:
(1) add `@_auth.turk_endpoint` to the endpoint in controllers (and `@_auth.requires_auth_or_turk` if your endpoint requires auth i.e takes in `credentials` in the function signature)
(2)  add the endpoint to the list of endpoints returning `*` for Access Control Allow Origin here: https://github.com/facebookresearch/dynabench/blob/main/api/common/cors.py#L15
(3) change the definition of the call in `ApiService` to check if the mode is in turk, and then call `doFetch` instead of `fetch` , making sure to pass in `false` for include credentials if in mturk mode (if `this.mode == "mturk"`) and `true` if otherwise. example here: https://github.com/facebookresearch/dynabench/blob/main/frontends/web/src/common/ApiService.js#L83