### PR TITLE
[FairScore] Add fairness perturbation script for AugLy and TextFlint

### DIFF
--- a/evaluation/scripts/perturb.py
+++ b/evaluation/scripts/perturb.py
@@ -149,7 +149,8 @@ def download_base_from_s3(args: Any) -> Optional[Tuple[str, str]]:
 
 def load_examples(path: str) -> List[Dict[str, Any]]:
     with open(path) as f:
-        return [json.loads(line) for line in f]
+        rows = f.readlines()
+        return [json.loads(line.strip(), strict=False) for line in rows]
 
 
 def perturb(

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -14,7 +14,7 @@ def load_examples(path: str) -> List[Dict[str, Any]]:
         return [json.loads(line) for line in f]
 
 
-def textflint_perturb_gender(examples):
+def textflint_perturb_gender(examples: List[Dict[str, Any]]) -> None:
     """Run TextFlint gender swaps using the Prejudice transformation.
 
     Store outputs as `textflint_rewrite` and update rows in place.
@@ -35,18 +35,20 @@ def textflint_perturb_gender(examples):
             row["textflint_rewrite"] = textflint_rewrite["x"]
 
 
-def write_perturb_outputs_to_csv(annotated_examples, augly_perturbed_examples, output_file):
+def write_perturb_outputs_to_csv(annotated_examples: List[Dict[str, Any]], augly_perturbed_examples: List[Dict[str, Any]], output_file: str) -> None:
     """Collate results from heuristic perturbation functions with original data and write to CSV path.
     """
     with open(output_file, "w") as csvfile:
         csv_writer = csv.writer(csvfile, delimiter="|")
-        csv_writer.writerow(["original", "text_with_params", "augly_rewrite", "textflint_rewrite", "perturber_rewrite", "annotator_rewrite"])
+        csv_writer.writerow(["original", "text_with_params", "augly_rewrite",
+                            "textflint_rewrite", "perturber_rewrite", "annotator_rewrite"])
         for annotated_ex, augly_output in zip(annotated_examples, augly_perturbed_examples):
-            # import ipdb; ipdb.set_trace
             if len(augly_output) == 0:
-                csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], annotated_ex["original"], annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
+                csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], annotated_ex["original"],
+                                    annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
                 continue
-            csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], augly_output[0]["original"], annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
+            csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], augly_output[0]["original"],
+                                annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
 
 
 def main():
@@ -72,13 +74,15 @@ def main():
     annotated_examples = load_examples(args.local_path)
 
     # Run AugLy perturbations on original text fields
-    pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=[])
+    pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=[
+                             "original"], ignore_words_fields=[])
     augly_perturbed_examples = pert.perturb(annotated_examples)
 
     textflint_perturb_gender(annotated_examples)
 
-    write_perturb_outputs_to_csv(annotated_examples, augly_perturbed_examples, args.output_file)
+    write_perturb_outputs_to_csv(
+        annotated_examples, augly_perturbed_examples, args.output_file)
 
-    
+
 if __name__ == "__main__":
     main()

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -1,10 +1,12 @@
-from augly_perturbation import AuglyPerturbation
+import argparse
+import csv
+import json
+from typing import Any, Dict, List
+
 from textflint import UTSample
 from textflint.generation.transformation.UT.prejudice import Prejudice
-from typing import Any, Dict, List
-import argparse
-import json
-import csv
+
+from augly_perturbation import AuglyPerturbation
 
 
 def load_examples(path: str) -> List[Dict[str, Any]]:

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -1,7 +1,7 @@
 from augly_perturbation import AuglyPerturbation
 from textflint import UTSample
 from textflint.generation.transformation.UT.prejudice import Prejudice
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 import argparse
 import json
 import csv

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -1,0 +1,86 @@
+from augly_perturbation import AuglyPerturbation
+import argparse
+import json
+import csv
+import ast
+
+def load_examples(path):
+    with open(path) as f:
+        return [json.loads(line) for line in f]
+
+# def load_examples(path):
+#     examples = []
+#     with open(path) as f:
+#         lines = f.readlines()
+#         for row in lines:
+#             task = ast.literal_eval(row)
+#             examples.append(task)
+#     return examples
+
+# examples = [{"original": "she is a farmer Mary Jane her", "uid": 123}]
+orig_examples = load_examples("/Users/rebeccaqian/fairscore/sst-sample-augly.jsonl")
+
+pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=[])
+perturbed_examples = pert.perturb(orig_examples)
+# print(perturbed_examples)
+
+with open("augly_perturbed.csv", "w") as csvfile:
+    csv_writer = csv.writer(csvfile, delimiter="|")
+    csv_writer.writerow(["original", "augly_rewrite", "annotator_rewrite"])
+    for orig, example in zip(orig_examples, perturbed_examples):
+        if len(example) == 0:
+            csv_writer.writerow([orig["original"], "", orig["annotator_rewrite"]])
+            continue
+        csv_writer.writerow([orig["original"], example[0]["original"], example[0]["annotator_rewrite"]])
+#                 continue
+#             # print(perturbed)
+#             # with open("fairness_dataset.csv", "w") as csvfile:
+#             # csv_writer = csv.writer(csvfile, delimiter="|")
+#             # csv_writer.writerow(example)
+#             # csv_writer.writerow(perturbed[0])
+#             csv_writer.writerow([example["context"], perturbed[0]["context"]])
+#             csv_writer.writerow([example["hypothesis"], perturbed[0]["hypothesis"]])
+# if __name__ == "__main__":
+#     parser = argparse.ArgumentParser()
+#     parser.add_argument(
+#         "--local_path",
+#         type=str,
+#         default="",
+#         help=(
+#             "Local path to a .jsonl file containing NLI examples"
+#         ),
+#     )
+#     args = parser.parse_args()
+#     print(args.local_path)
+
+#     orig_csv_writer = csv.writer(open("mnli_unchanged_examples.csv", "w"), delimiter="|")
+#     orig_csv_writer.writerow(["Original"])
+
+#     # Save the perturbed data samples
+#     perturbed_pairs = []
+#     with open("fairness_dataset.csv", "w") as csvfile:
+#         csv_writer = csv.writer(csvfile, delimiter="|")
+#         csv_writer.writerow(["Original", "Perturbed"])
+
+#         pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=["annotator_rewrite"])
+#         orig_examples = load_examples(args.local_path)
+#         import ipdb; ipdb.set_trace()
+#         for example in orig_examples:
+#             # print("Original:")
+#             # print(example)
+#             # print("Perturbed:")
+#             perturbed = pert.perturb("nli", example)
+#             if len(perturbed) == 0:
+#                 # print("Nothing to perturb")
+#                 orig_csv_writer.writerow([example["context"]])
+#                 orig_csv_writer.writerow([example["hypothesis"]])
+#                 continue
+#             # print(perturbed)
+#             # with open("fairness_dataset.csv", "w") as csvfile:
+#             # csv_writer = csv.writer(csvfile, delimiter="|")
+#             # csv_writer.writerow(example)
+#             # csv_writer.writerow(perturbed[0])
+#             csv_writer.writerow([example["context"], perturbed[0]["context"]])
+#             csv_writer.writerow([example["hypothesis"], perturbed[0]["hypothesis"]])
+
+            # ex = [{"uid": "960", "col": "She is a farmer Mary Jane her. Still Standing is a song by American R&B singer Monica, written by Christopher Bridges, Adonis Shropshire, Bryan-Michael Cox and Monica for her sixth studio album, \"Still Standing\" (2010). Produced by Bryan-Michael Cox, it features guest vocals by her cousin and rapper Ludacris. Still Standing has been heard by trump", "annotator_rewrite": "``Still Standing'' is a song by American R & B singer Mark, written by Christopher Bridges, Adonis Shropshire, Bryan-Michael Cox and Mark for his sixth studio album , `` Still Standing'' ( 2010 ) . Produced by Bryan-Michael Cox, it features guest vocals by her cousin and rapper Ludacris . Still Standing has been heard by trump. She is a farmer Mary Jane her"}]

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -93,9 +93,7 @@ def main():
         "--output_file",
         type=str,
         required=True,
-        help=(
-            "Path to a .csv file to save heuristically perturbed outputs"
-        ),
+        help=("Path to a .csv file to save heuristically perturbed outputs"),
     )
     args = parser.parse_args()
 

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -1,4 +1,6 @@
 from augly_perturbation import AuglyPerturbation
+from textflint import UTSample
+from textflint.generation.transformation.UT.prejudice import Prejudice
 import argparse
 import json
 import csv
@@ -32,15 +34,25 @@ def main():
 
     pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=[])
     perturbed_examples = pert.perturb(orig_examples)
+    for ex in orig_examples:
+        ex["x"] = ex["original"]
+        sample = UTSample(ex)
+        trans = Prejudice(change_type="Name")
+        trans_sample = trans.transform(sample)
+        if trans_sample == []:
+            ex["textflint_rewrite"] = ex["original"]
+        else:
+            textflint_rewrite = trans_sample[0].dump()
+            ex["textflint_rewrite"] = textflint_rewrite["x"]
 
     with open(args.output_file, "w") as csvfile:
         csv_writer = csv.writer(csvfile, delimiter="|")
-        csv_writer.writerow(["original", "text_with_params", "augly_rewrite", "perturber_rewrite", "annotator_rewrite"])
+        csv_writer.writerow(["original", "text_with_params", "augly_rewrite", "textflint_rewrite", "perturber_rewrite", "annotator_rewrite"])
         for orig, example in zip(orig_examples, perturbed_examples):
             if len(example) == 0:
-                csv_writer.writerow([orig["original"], orig["text_with_params"], orig["original"], orig["perturber_rewrite"], orig["annotator_rewrite"]])
+                csv_writer.writerow([orig["original"], orig["text_with_params"], orig["original"], orig["textflint_rewrite"], orig["perturber_rewrite"], orig["annotator_rewrite"]])
                 continue
-            csv_writer.writerow([orig["original"], orig["text_with_params"], example[0]["original"], orig["perturber_rewrite"], example[0]["annotator_rewrite"]])
+            csv_writer.writerow([orig["original"], orig["text_with_params"], example[0]["original"], orig["textflint_rewrite"], orig["perturber_rewrite"], example[0]["annotator_rewrite"]])
 
     
 if __name__ == "__main__":

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -2,85 +2,46 @@ from augly_perturbation import AuglyPerturbation
 import argparse
 import json
 import csv
-import ast
 
 def load_examples(path):
     with open(path) as f:
         return [json.loads(line) for line in f]
 
-# def load_examples(path):
-#     examples = []
-#     with open(path) as f:
-#         lines = f.readlines()
-#         for row in lines:
-#             task = ast.literal_eval(row)
-#             examples.append(task)
-#     return examples
 
-# examples = [{"original": "she is a farmer Mary Jane her", "uid": 123}]
-orig_examples = load_examples("/Users/rebeccaqian/fairscore/sst-sample-augly.jsonl")
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--local_path",
+        type=str,
+        default="o",
+        help=(
+            "Local path to a .jsonl file containing annotator and perturber rewrites"
+        ),
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        default="03-05-allowlist-test-set-gender.csv",
+        help=(
+            "Local path to a .jsonl file containing annotator and perturber rewrites"
+        ),
+    )
+    args = parser.parse_args()
 
-pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=[])
-perturbed_examples = pert.perturb(orig_examples)
-# print(perturbed_examples)
+    orig_examples = load_examples(args.local_path)
 
-with open("augly_perturbed.csv", "w") as csvfile:
-    csv_writer = csv.writer(csvfile, delimiter="|")
-    csv_writer.writerow(["original", "augly_rewrite", "annotator_rewrite"])
-    for orig, example in zip(orig_examples, perturbed_examples):
-        if len(example) == 0:
-            csv_writer.writerow([orig["original"], "", orig["annotator_rewrite"]])
-            continue
-        csv_writer.writerow([orig["original"], example[0]["original"], example[0]["annotator_rewrite"]])
-#                 continue
-#             # print(perturbed)
-#             # with open("fairness_dataset.csv", "w") as csvfile:
-#             # csv_writer = csv.writer(csvfile, delimiter="|")
-#             # csv_writer.writerow(example)
-#             # csv_writer.writerow(perturbed[0])
-#             csv_writer.writerow([example["context"], perturbed[0]["context"]])
-#             csv_writer.writerow([example["hypothesis"], perturbed[0]["hypothesis"]])
-# if __name__ == "__main__":
-#     parser = argparse.ArgumentParser()
-#     parser.add_argument(
-#         "--local_path",
-#         type=str,
-#         default="",
-#         help=(
-#             "Local path to a .jsonl file containing NLI examples"
-#         ),
-#     )
-#     args = parser.parse_args()
-#     print(args.local_path)
+    pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=[])
+    perturbed_examples = pert.perturb(orig_examples)
 
-#     orig_csv_writer = csv.writer(open("mnli_unchanged_examples.csv", "w"), delimiter="|")
-#     orig_csv_writer.writerow(["Original"])
+    with open(args.output_file, "w") as csvfile:
+        csv_writer = csv.writer(csvfile, delimiter="|")
+        csv_writer.writerow(["original", "text_with_params", "augly_rewrite", "perturber_rewrite", "annotator_rewrite"])
+        for orig, example in zip(orig_examples, perturbed_examples):
+            if len(example) == 0:
+                csv_writer.writerow([orig["original"], orig["text_with_params"], orig["original"], orig["perturber_rewrite"], orig["annotator_rewrite"]])
+                continue
+            csv_writer.writerow([orig["original"], orig["text_with_params"], example[0]["original"], orig["perturber_rewrite"], example[0]["annotator_rewrite"]])
 
-#     # Save the perturbed data samples
-#     perturbed_pairs = []
-#     with open("fairness_dataset.csv", "w") as csvfile:
-#         csv_writer = csv.writer(csvfile, delimiter="|")
-#         csv_writer.writerow(["Original", "Perturbed"])
-
-#         pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=["annotator_rewrite"])
-#         orig_examples = load_examples(args.local_path)
-#         import ipdb; ipdb.set_trace()
-#         for example in orig_examples:
-#             # print("Original:")
-#             # print(example)
-#             # print("Perturbed:")
-#             perturbed = pert.perturb("nli", example)
-#             if len(perturbed) == 0:
-#                 # print("Nothing to perturb")
-#                 orig_csv_writer.writerow([example["context"]])
-#                 orig_csv_writer.writerow([example["hypothesis"]])
-#                 continue
-#             # print(perturbed)
-#             # with open("fairness_dataset.csv", "w") as csvfile:
-#             # csv_writer = csv.writer(csvfile, delimiter="|")
-#             # csv_writer.writerow(example)
-#             # csv_writer.writerow(perturbed[0])
-#             csv_writer.writerow([example["context"], perturbed[0]["context"]])
-#             csv_writer.writerow([example["hypothesis"], perturbed[0]["hypothesis"]])
-
-            # ex = [{"uid": "960", "col": "She is a farmer Mary Jane her. Still Standing is a song by American R&B singer Monica, written by Christopher Bridges, Adonis Shropshire, Bryan-Michael Cox and Monica for her sixth studio album, \"Still Standing\" (2010). Produced by Bryan-Michael Cox, it features guest vocals by her cousin and rapper Ludacris. Still Standing has been heard by trump", "annotator_rewrite": "``Still Standing'' is a song by American R & B singer Mark, written by Christopher Bridges, Adonis Shropshire, Bryan-Michael Cox and Mark for his sixth studio album , `` Still Standing'' ( 2010 ) . Produced by Bryan-Michael Cox, it features guest vocals by her cousin and rapper Ludacris . Still Standing has been heard by trump. She is a farmer Mary Jane her"}]
+    
+if __name__ == "__main__":
+    main()

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -8,8 +8,7 @@ import csv
 
 
 def load_examples(path: str) -> List[Dict[str, Any]]:
-    """Load examples in .jsonl format
-    """
+    """Load examples in .jsonl format"""
     with open(path) as f:
         return [json.loads(line) for line in f]
 
@@ -35,20 +34,49 @@ def textflint_perturb_gender(examples: List[Dict[str, Any]]) -> None:
             row["textflint_rewrite"] = textflint_rewrite["x"]
 
 
-def write_perturb_outputs_to_csv(annotated_examples: List[Dict[str, Any]], augly_perturbed_examples: List[Dict[str, Any]], output_file: str) -> None:
-    """Collate results from heuristic perturbation functions with original data and write to CSV path.
-    """
+def write_perturb_outputs_to_csv(
+    annotated_examples: List[Dict[str, Any]],
+    augly_perturbed_examples: List[Dict[str, Any]],
+    output_file: str,
+) -> None:
+    """Collate results from heuristic perturbation functions with original data and write to CSV path."""
     with open(output_file, "w") as csvfile:
         csv_writer = csv.writer(csvfile, delimiter="|")
-        csv_writer.writerow(["original", "text_with_params", "augly_rewrite",
-                            "textflint_rewrite", "perturber_rewrite", "annotator_rewrite"])
-        for annotated_ex, augly_output in zip(annotated_examples, augly_perturbed_examples):
+        csv_writer.writerow(
+            [
+                "original",
+                "text_with_params",
+                "augly_rewrite",
+                "textflint_rewrite",
+                "perturber_rewrite",
+                "annotator_rewrite",
+            ]
+        )
+        for annotated_ex, augly_output in zip(
+            annotated_examples, augly_perturbed_examples
+        ):
             if len(augly_output) == 0:
-                csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], annotated_ex["original"],
-                                    annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
+                csv_writer.writerow(
+                    [
+                        annotated_ex["original"],
+                        annotated_ex["text_with_params"],
+                        annotated_ex["original"],
+                        annotated_ex["textflint_rewrite"],
+                        annotated_ex["perturber_rewrite"],
+                        annotated_ex["annotator_rewrite"],
+                    ]
+                )
                 continue
-            csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], augly_output[0]["original"],
-                                annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
+            csv_writer.writerow(
+                [
+                    annotated_ex["original"],
+                    annotated_ex["text_with_params"],
+                    augly_output[0]["original"],
+                    annotated_ex["textflint_rewrite"],
+                    annotated_ex["perturber_rewrite"],
+                    annotated_ex["annotator_rewrite"],
+                ]
+            )
 
 
 def main():
@@ -66,7 +94,7 @@ def main():
         type=str,
         required=True,
         help=(
-            "Local path to a .jsonl file containing annotator and perturber rewrites"
+            "Path to a .csv file to save heuristically perturbed outputs"
         ),
     )
     args = parser.parse_args()
@@ -74,14 +102,20 @@ def main():
     annotated_examples = load_examples(args.local_path)
 
     # Run AugLy perturbations on original text fields
-    pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=[
-                             "original"], ignore_words_fields=[])
+    pert = AuglyPerturbation(
+        perturb_prefix="fairness",
+        seed=2000,
+        num_threads=1,
+        perturb_fields=["original"],
+        ignore_words_fields=[],
+    )
     augly_perturbed_examples = pert.perturb(annotated_examples)
 
     textflint_perturb_gender(annotated_examples)
 
     write_perturb_outputs_to_csv(
-        annotated_examples, augly_perturbed_examples, args.output_file)
+        annotated_examples, augly_perturbed_examples, args.output_file
+    )
 
 
 if __name__ == "__main__":

--- a/evaluation/scripts/perturb_fairscore.py
+++ b/evaluation/scripts/perturb_fairscore.py
@@ -1,13 +1,52 @@
 from augly_perturbation import AuglyPerturbation
 from textflint import UTSample
 from textflint.generation.transformation.UT.prejudice import Prejudice
+from typing import Any, Dict, List, Optional, Tuple
 import argparse
 import json
 import csv
 
-def load_examples(path):
+
+def load_examples(path: str) -> List[Dict[str, Any]]:
+    """Load examples in .jsonl format
+    """
     with open(path) as f:
         return [json.loads(line) for line in f]
+
+
+def textflint_perturb_gender(examples):
+    """Run TextFlint gender swaps using the Prejudice transformation.
+
+    Store outputs as `textflint_rewrite` and update rows in place.
+    """
+    for row in examples:
+        # TextFlint requires field "x" to be set
+        row["x"] = row["original"]
+        # Initialize a Universal Transformation sample with the example
+        sample = UTSample(row)
+        # Name is the gender transform change type
+        gender_transform = Prejudice(change_type="Name")
+        transform_sample = gender_transform.transform(sample)
+        if transform_sample == []:
+            # If TextFlint did not detect any words to swap, use the original rewrite
+            row["textflint_rewrite"] = row["original"]
+        else:
+            textflint_rewrite = transform_sample[0].dump()
+            row["textflint_rewrite"] = textflint_rewrite["x"]
+
+
+def write_perturb_outputs_to_csv(annotated_examples, augly_perturbed_examples, output_file):
+    """Collate results from heuristic perturbation functions with original data and write to CSV path.
+    """
+    with open(output_file, "w") as csvfile:
+        csv_writer = csv.writer(csvfile, delimiter="|")
+        csv_writer.writerow(["original", "text_with_params", "augly_rewrite", "textflint_rewrite", "perturber_rewrite", "annotator_rewrite"])
+        for annotated_ex, augly_output in zip(annotated_examples, augly_perturbed_examples):
+            # import ipdb; ipdb.set_trace
+            if len(augly_output) == 0:
+                csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], annotated_ex["original"], annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
+                continue
+            csv_writer.writerow([annotated_ex["original"], annotated_ex["text_with_params"], augly_output[0]["original"], annotated_ex["textflint_rewrite"], annotated_ex["perturber_rewrite"], annotated_ex["annotator_rewrite"]])
 
 
 def main():
@@ -15,7 +54,7 @@ def main():
     parser.add_argument(
         "--local_path",
         type=str,
-        default="o",
+        required=True,
         help=(
             "Local path to a .jsonl file containing annotator and perturber rewrites"
         ),
@@ -23,36 +62,22 @@ def main():
     parser.add_argument(
         "--output_file",
         type=str,
-        default="03-05-allowlist-test-set-gender.csv",
+        required=True,
         help=(
             "Local path to a .jsonl file containing annotator and perturber rewrites"
         ),
     )
     args = parser.parse_args()
 
-    orig_examples = load_examples(args.local_path)
+    annotated_examples = load_examples(args.local_path)
 
+    # Run AugLy perturbations on original text fields
     pert = AuglyPerturbation(perturb_prefix="fairness", seed=2000, num_threads=1, perturb_fields=["original"], ignore_words_fields=[])
-    perturbed_examples = pert.perturb(orig_examples)
-    for ex in orig_examples:
-        ex["x"] = ex["original"]
-        sample = UTSample(ex)
-        trans = Prejudice(change_type="Name")
-        trans_sample = trans.transform(sample)
-        if trans_sample == []:
-            ex["textflint_rewrite"] = ex["original"]
-        else:
-            textflint_rewrite = trans_sample[0].dump()
-            ex["textflint_rewrite"] = textflint_rewrite["x"]
+    augly_perturbed_examples = pert.perturb(annotated_examples)
 
-    with open(args.output_file, "w") as csvfile:
-        csv_writer = csv.writer(csvfile, delimiter="|")
-        csv_writer.writerow(["original", "text_with_params", "augly_rewrite", "textflint_rewrite", "perturber_rewrite", "annotator_rewrite"])
-        for orig, example in zip(orig_examples, perturbed_examples):
-            if len(example) == 0:
-                csv_writer.writerow([orig["original"], orig["text_with_params"], orig["original"], orig["textflint_rewrite"], orig["perturber_rewrite"], orig["annotator_rewrite"]])
-                continue
-            csv_writer.writerow([orig["original"], orig["text_with_params"], example[0]["original"], orig["textflint_rewrite"], orig["perturber_rewrite"], example[0]["annotator_rewrite"]])
+    textflint_perturb_gender(annotated_examples)
+
+    write_perturb_outputs_to_csv(annotated_examples, augly_perturbed_examples, args.output_file)
 
     
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adding a heuristic perturbation script running AugLy and TextFlint gender perturbations for the FairScore project.
- Load `.jsonl` file containing annotated examples of text rewrites swapping gendered references along binary gender axis (M, F).
- Run AugLy fairness perturbations on set of examples, as in the `perturb.py` script.
- Run TextFlint fairness perturbations by transforming each example. See the [`Prejudice` class](https://github.com/textflint/textflint/blob/83a51030246c63f0344364e4da30a23554d42ea7/textflint/generation/transformation/UT/prejudice.py) for details.
- Output pandas dataframe in `.csv` format containing AugLy and TextFlint perturbed outputs for each text input, collated with original annotated parameters.

Note that while we collect non-binary rewrites, we only run heuristic perturbation on binary genders because the modules do not support non-binary pronoun swaps. Both AugLy and TextFlint support race-based perturbations, but since there is no control over generation, we cannot run a fair comparison between libraries for perturbations that are not 1-1.

### Example Usage
```
python perturb_fairscore.py \
    --local_path /path_to_data_dir/test-set-gender.jsonl \
    --output_file /path_to_data_dir/test-set-gender.csv`
```

