### PR TITLE
decentralized fixes

### DIFF
--- a/api/models/task.py
+++ b/api/models/task.py
@@ -9,7 +9,6 @@ import enum
 import requests
 import sqlalchemy as db
 import yaml
-from transformers.data.metrics.squad_metrics import compute_f1
 
 import common.helpers as util
 from common.logging import logger
@@ -76,6 +75,8 @@ def verify_exact_match_config(config_obj):
 
 
 def string_f1(output, target, config_obj):
+    from transformers.data.metrics.squad_metrics import compute_f1
+
     return (
         compute_f1(
             output[config_obj["reference_name"]],

--- a/builder/build_config.py.example
+++ b/builder/build_config.py.example
@@ -1,10 +1,20 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 build_config = {
-    "aws_access_key_id": "",
-    "aws_secret_access_key": "",
-    "aws_region": "",
+    # AWS credentials. Can be hard coded or you can also let them to None
+    # and AWS will use the permissions from the EC2 instance running the server.
+    "aws_access_key_id": None,
+    "aws_secret_access_key": None,
+    # This is the region where the SQS queue is.
+    # Decentralized: It needs to be the same region than the main dynabench.org websites uses in the backend.
+    "aws_region": "us-west-1",
+    # Decentralized: Allow to override the region to run the sagemaker jobs from
+    # This allows to migrate more easily the most expensive part of the evaluation.
+    # This need to be kept in sync with eval_config.py
+    # "sagemaker_region": "us-west-2",
     "sagemaker_role": "",
+    # Decentralized: An S3 bucket where to upload the models
+    # "model_s3_bucket": "models"
     "gateway_url": "",
     "queue_dump": "queue.dump",
 }

--- a/builder/build_server_decen.py
+++ b/builder/build_server_decen.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import json
+import logging
 import os
 import pickle
 import time
@@ -20,7 +21,17 @@ from utils.helpers import (
 from utils.logging import init_logger, logger
 
 
-if __name__ == "__main__":
+REQUIRED_BUILD_MESSAGE_KEYS = {
+    "model_id",
+    "s3_uri",
+    "model_info",
+    "task_info",
+    # "endpoint_only",
+    # "decen_eaas",
+}
+
+
+def main():
     init_logger("builder")
     logger.info("Start build server")
     sqs = boto3.resource(
@@ -29,6 +40,14 @@ if __name__ == "__main__":
         aws_secret_access_key=build_config["aws_secret_access_key"],
         region_name=build_config["aws_region"],
     )
+    session = boto3.Session(
+        aws_access_key_id=build_config["aws_access_key_id"],
+        aws_secret_access_key=build_config["aws_secret_access_key"],
+        region_name=build_config["aws_region"],
+    )
+
+    s3_client = session.client("s3")
+    logging.getLogger("boto3.resources.action").setLevel(logging.DEBUG)
     queue = sqs.get_queue_by_name(QueueName=build_config["builder_sqs_queue"])
     eval_queue = sqs.get_queue_by_name(QueueName=build_config["evaluation_sqs_queue"])
     redeployment_queue = load_queue_dump(build_config["queue_dump"], logger=logger)
@@ -40,133 +59,130 @@ if __name__ == "__main__":
     while True:
         try:
             for message in queue.receive_messages():
-                msg = json.loads(message.body)
-                logger.info(f"Build server received SQS message {msg}")
+                try:
+                    msg = json.loads(message.body)
+                    logger.info(f"Build server received SQS message {msg}")
 
-                if set(msg.keys()) <= {
-                    "model_id",
-                    "s3_uri",
-                    "model_info",
-                    "task_info",
-                    "endpoint_only",
-                    "decen_eaas",
-                }:
+                    if not (set(msg.keys()) >= REQUIRED_BUILD_MESSAGE_KEYS):
+                        logging.warning(
+                            f"Received invalid message with keys: {list(msg.keys())}"
+                        )
+                        ack(queue, message)
+                        continue
+
                     model_id = msg["model_id"]
                     s3_uri = msg["s3_uri"]
                     endpoint_only = msg.get("endpoint_only", False)
 
-                    # if "model_info" in msg.keys():
-                    json_model = json.loads(msg.get("model_info", None))
-                    json_model["task"] = dotdict(json.loads(msg.get("task_info")))
+                    json_model = json.loads(msg["model_info"])
+                    json_model["task"] = dotdict(json.loads(msg["task_info"]))
+                    breakpoint()
                     model = dotdict(json_model)
+                except Exception as e:
+                    logging.error(f"Failed to parse queue message: {msg}")
+                    ack(queue, message)
+                    continue
 
-                    if (
-                        model.deployment_status == "uploaded"
-                        or model.deployment_status == "takendownnonactive"
-                    ):
+                if (
+                    model.deployment_status == "uploaded"
+                    or model.deployment_status == "takendownnonactive"
+                ):
 
-                        if model.deployment_status == "uploaded":
-                            model_id = model.id
-                            model_secret = model.secret
-                            model_endpoint_name = model.endpoint_name
-                            model_task_code = model.task.task_code
-                            # model_task_bucket = model.task.s3_bucket
-
-                            logger.info("Starting to download the model to s3 bucket")
-                            model_download_filename = api_download_model(
-                                model_id, model_secret
-                            )
-
-                            s3_filename = f"{model_endpoint_name}.tar.gz"
-                            s3_path = (
-                                f"torchserve/models/{model_task_code}/{s3_filename}"
-                            )
-                            # bucket_name = model_task_bucket
-                            bucket_name = build_config["model_s3_bucket"]
-
-                            session = boto3.Session(
-                                aws_access_key_id=build_config["aws_access_key_id"],
-                                aws_secret_access_key=build_config[
-                                    "aws_secret_access_key"
-                                ],
-                                region_name=build_config["aws_region"],
-                            )
-                            s3_client = session.client("s3")
-                            response = s3_client.upload_fileobj(
-                                open(model_download_filename, "rb"),
-                                bucket_name,
-                                s3_path,
-                            )
-                            if response:
-                                logger.info(
-                                    f"Response from the mar file upload to s3 {response}"
-                                )
-
-                            os.remove(model_download_filename)
-
-                        # deploy model
-                        logger.info(f"Start to deploy model {model_id}")
-                        api_model_update(model, "processing")
-                        deployer = ModelDeployer(model)
-                        new_s3_uri = deployer.decen_change_s3_bucket_to_config(s3_uri)
-                        response = deployer.deploy(
-                            new_s3_uri,
-                            endpoint_only=endpoint_only,
-                            decen=True,
-                            decen_task_info=msg.get("task_info"),
+                    if model.deployment_status == "uploaded":
+                        logger.info("Starting to download the model to s3 bucket")
+                        model_download_filename = api_download_model(
+                            model.id, model.secret
                         )
 
-                        # process deployment result
-                        msg["name"] = model.name
-                        msg["exception"] = response["ex_msg"]
-                        # TODO: BE, make this code block more elegant
-                        if response["status"] == "delayed":
-                            redeployment_queue.append(msg)
-                            pickle.dump(
-                                redeployment_queue,
-                                open(build_config["queue_dump"], "wb"),
-                            )
-                            api_model_update(model, "uploaded")
-                            subject = f"Model {model.name} deployment delayed"
-                            template = "model_deployment_fail"
-                        elif response["status"] == "failed":
-                            api_model_update(model, "failed")
-                            subject = f"Model {model.name} deployment failed"
-                            template = "model_deployment_fail"
-                        elif (
-                            response["status"] == "deployed"
-                            or response["status"] == "created"
-                        ):
-                            if response["status"] == "deployed":
-                                api_model_update(model, "deployed")
-                            else:
-                                api_model_update(model, "created")
-                            subject = f"Model {model.name} deployment successful"
-                            template = "model_deployment_successful"
-                            eval_message = {
-                                "model_id": model_id,
-                                "eval_server_id": model.task.eval_server_id,
-                            }
-                            eval_queue.send_message(
-                                MessageBody=json.dumps(eval_message)
+                        s3_filename = f"{model.endpoint_name}.tar.gz"
+                        s3_path = (
+                            f"torchserve/models/{model.task.task_code}/{s3_filename}"
+                        )
+                        # bucket_name = model_task_bucket
+                        bucket_name = build_config["model_s3_bucket"]
+
+                        response = s3_client.upload_fileobj(
+                            open(model_download_filename, "rb"),
+                            bucket_name,
+                            s3_path,
+                        )
+                        if response:
+                            logger.info(
+                                f"Response from the mar file upload to s3 {response}"
                             )
 
-                        # send email
-                        api_send_email(model, msg, subject, template)
-                    elif model.deployment_status == "failed":
-                        logger.info(f"Clean up failed model {model.endpoint_name}")
-                        deployer = ModelDeployer(model)
-                        deployer.cleanup_on_failure(s3_uri)
-                        api_model_update(model, "takendown")
-                queue.delete_messages(
-                    Entries=[
-                        {
-                            "Id": str(uuid.uuid4()),
-                            "ReceiptHandle": message.receipt_handle,
+                        os.remove(model_download_filename)
+
+                    # deploy model
+                    logger.info(f"Start to deploy model {model.id}")
+                    api_model_update(model, "processing")
+                    deployer = ModelDeployer(model)
+                    new_s3_uri = deployer.decen_change_s3_bucket_to_config(s3_uri)
+                    response = deployer.deploy(
+                        new_s3_uri,
+                        endpoint_only=endpoint_only,
+                        decen=True,
+                        decen_task_info=msg.get("task_info"),
+                    )
+
+                    # process deployment result
+                    msg["name"] = model.name
+                    msg["exception"] = response["ex_msg"]
+                    # TODO: BE, make this code block more elegant
+                    if response["status"] == "delayed":
+                        redeployment_queue.append(msg)
+                        pickle.dump(
+                            redeployment_queue,
+                            open(build_config["queue_dump"], "wb"),
+                        )
+                        api_model_update(model, "uploaded")
+                        subject = f"Model {model.name} deployment delayed"
+                        template = "model_deployment_fail"
+                    elif response["status"] == "failed":
+                        api_model_update(model, "failed")
+                        subject = f"Model {model.name} deployment failed"
+                        template = "model_deployment_fail"
+                    elif (
+                        response["status"] == "deployed"
+                        or response["status"] == "created"
+                    ):
+                        if response["status"] == "deployed":
+                            api_model_update(model, "deployed")
+                        else:
+                            api_model_update(model, "created")
+                        subject = f"Model {model.name} deployment successful"
+                        template = "model_deployment_successful"
+                        eval_message = {
+                            "model_id": model.id,
+                            "eval_server_id": model.task.eval_server_id,
                         }
-                    ]
-                )
+                        eval_queue.send_message(MessageBody=json.dumps(eval_message))
+
+                    # send email
+                    api_send_email(model, msg, subject, template)
+                elif model.deployment_status == "failed":
+                    logger.info(f"Clean up failed model {model.endpoint_name}")
+                    deployer = ModelDeployer(model)
+                    deployer.cleanup_on_failure(s3_uri)
+                    api_model_update(model, "takendown")
+
+                ack(queue, message)
+
             time.sleep(5)
         except Exception as e:
-            logger.info(f"Got exception while processing request: {message.body}")
-            print(e)
+            logger.exception(f"Got exception while processing request: {message.body}")
+
+
+def ack(queue, message) -> None:
+    queue.delete_messages(
+        Entries=[
+            {
+                "Id": str(uuid.uuid4()),
+                "ReceiptHandle": message.receipt_handle,
+            }
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/builder/dockerfiles/Dockerfile
+++ b/builder/dockerfiles/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /tmp \
     && curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py \
     && python3 get-pip.py
 
-RUN python -m pip install --no-cache-dir torchserve nvgpu
+RUN python -m pip install --no-cache-dir torchserve
 RUN python -m pip install --no-cache-dir torch==1.8.1
 
 COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh

--- a/builder/dockerfiles/Dockerfile
+++ b/builder/dockerfiles/Dockerfile
@@ -32,7 +32,7 @@ RUN cd /tmp \
     && curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py \
     && python3 get-pip.py
 
-RUN python -m pip install --no-cache-dir torchserve
+RUN python -m pip install --no-cache-dir torchserve nvgpu
 RUN python -m pip install --no-cache-dir torch==1.8.1
 
 COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
@@ -48,7 +48,7 @@ WORKDIR /home/model-server/code
 
 RUN if [ -f requirements.txt ] && [ ${requirements} = True ]; then python -m pip install --no-cache-dir --force-reinstall -r requirements.txt; fi
 RUN if [ -f setup.py ] && [ ${setup} = True ]; then python -m pip install --no-cache-dir --force-reinstall -e .; fi
-RUN python -m pip install --force-reinstall git+git://github.com/facebookresearch/dynalab.git
+RUN python -m pip install --force-reinstall git+https://github.com/facebookresearch/dynalab.git
 
 RUN echo 'from dynalab.tasks.task_io import TaskIO; TaskIO("'${task_code}'")'
 RUN python -c 'from dynalab.tasks.task_io import TaskIO; TaskIO("'${task_code}'")'

--- a/builder/dockerfiles/gpu.Dockerfile
+++ b/builder/dockerfiles/gpu.Dockerfile
@@ -32,7 +32,9 @@ RUN cd /tmp \
     && curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py \
     && python3 get-pip.py
 
-RUN python -m pip install --no-cache-dir torchserve
+# Explicitly install nvgpu until the issue is fixed
+# https://github.com/pytorch/serve/issues/1516
+RUN python -m pip install --no-cache-dir torchserve nvgpu
 RUN python -m pip install --no-cache-dir torch==1.8.1
 
 COPY dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh
@@ -48,7 +50,7 @@ WORKDIR /home/model-server/code
 
 RUN if [ -f requirements.txt ] && [ ${requirements} = True ]; then python -m pip install --no-cache-dir --force-reinstall -r requirements.txt; fi
 RUN if [ -f setup.py ] && [ ${setup} = True ]; then python -m pip install --no-cache-dir --force-reinstall -e .; fi
-RUN python -m pip install --force-reinstall git+git://github.com/facebookresearch/dynalab.git
+RUN python -m pip install --force-reinstall git+https://github.com/facebookresearch/dynalab.git
 
 RUN echo 'from dynalab.tasks.task_io import TaskIO; TaskIO("'${task_code}'")'
 RUN python -c 'from dynalab.tasks.task_io import TaskIO; TaskIO("'${task_code}'")'

--- a/builder/utils/deployer.py
+++ b/builder/utils/deployer.py
@@ -114,7 +114,7 @@ class ModelDeployer:
 
     def setup_sagemaker_env(self):
         env = {}
-        region = self.model.task.aws_region
+        region = self.config.get("sagemaker_region") or self.model.task.aws_region
         session = boto3.Session(
             aws_access_key_id=build_config["aws_access_key_id"],
             aws_secret_access_key=build_config["aws_secret_access_key"],

--- a/builder/utils/deployer.py
+++ b/builder/utils/deployer.py
@@ -114,7 +114,7 @@ class ModelDeployer:
 
     def setup_sagemaker_env(self):
         env = {}
-        region = self.config.get("sagemaker_region") or self.model.task.aws_region
+        region = self.config.get("sagemaker_region") or self.config.get("aws_region")
         session = boto3.Session(
             aws_access_key_id=build_config["aws_access_key_id"],
             aws_secret_access_key=build_config["aws_secret_access_key"],

--- a/evaluation/datasets/__init__.py
+++ b/evaluation/datasets/__init__.py
@@ -9,13 +9,13 @@ import sys
 
 sys.path.append("../api")  # noqa
 # TODO: find a way not to comment the follow imports to skip linter
-from models.dataset import DatasetModel  # isort:skip
-from models.task import TaskModel  # isort:skip
 from datasets.common import BaseDataset  # isort:skip
 from datasets.mt import flores  # isort:skip
 
 
 def load_datasets():
+    from models.dataset import DatasetModel  # isort:skip
+    from models.task import TaskModel  # isort:skip
     dm = DatasetModel()
     datasets = dm.list()
 

--- a/evaluation/datasets/__init__.py
+++ b/evaluation/datasets/__init__.py
@@ -14,8 +14,9 @@ from datasets.mt import flores  # isort:skip
 
 
 def load_datasets():
-    from models.dataset import DatasetModel  # isort:skip
-    from models.task import TaskModel  # isort:skip
+    from models.dataset import DatasetModel
+    from models.task import TaskModel
+
     dm = DatasetModel()
     datasets = dm.list()
 

--- a/evaluation/datasets/common.py
+++ b/evaluation/datasets/common.py
@@ -73,7 +73,7 @@ class BaseDataset:
     @property
     def s3_client(self):
         if self._s3_client is None:
-            region = getattr(self.task, "aws_region", None) or self._config["aws_region"]
+            region = self._config["sagemaker_region"] or self._config["aws_region"]
             self._s3_client = boto3.client(
                 "s3",
                 aws_access_key_id=self._config["aws_access_key_id"],

--- a/evaluation/datasets/common.py
+++ b/evaluation/datasets/common.py
@@ -73,11 +73,12 @@ class BaseDataset:
     @property
     def s3_client(self):
         if self._s3_client is None:
+            region = getattr(self.task, "aws_region", None) or self._config["aws_region"]
             self._s3_client = boto3.client(
                 "s3",
                 aws_access_key_id=self._config["aws_access_key_id"],
                 aws_secret_access_key=self._config["aws_secret_access_key"],
-                region_name=self._config["aws_region"],
+                region_name=region,
             )
         return self._s3_client
 

--- a/evaluation/eval_config.py.example
+++ b/evaluation/eval_config.py.example
@@ -1,10 +1,18 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 eval_config = {
-    "aws_access_key_id": "",
-    "aws_secret_access_key": "",
-    "aws_region": "",
-    "sagemaker_role": "",
+    # AWS credentials. Can be hard coded or you can also let them to None
+    # and AWS will use the permissions from the EC2 instance running the server.
+    "aws_access_key_id": None,
+    "aws_secret_access_key": None,
+    # This is the region where the SQS queue is.
+    # It needs to be the same region than the main dynabench.org websites uses in the backend.
+    "aws_region": "us-west-1",
+    # Allow to override the region to run the sagemaker jobs from
+    # This allows to migrate more easily the most expensive part of the evaluation.
+    # This need to be kept in sync with build_config.py
+    # "sagemaker_region": "us-west-2",
+    "sagemaker_role": "sagemaker_role",
     "dataset_s3_bucket": "",
     "evaluation_sqs_queue": "",
     "scheduler_status_dump": "scheduler.dump",

--- a/evaluation/eval_server_decen.py
+++ b/evaluation/eval_server_decen.py
@@ -281,9 +281,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-"""
-{"model_id": 615, "eval_server_id": "flores101"}
-{'model_id': 621, 'eval_server_id': 'flores101'}
-
-"""

--- a/evaluation/metrics/metrics.py
+++ b/evaluation/metrics/metrics.py
@@ -11,7 +11,6 @@ import numpy as np
 import sacrebleu
 import sentencepiece
 from sklearn.metrics import f1_score
-from transformers.data.metrics.squad_metrics import compute_f1
 
 from metrics.instance_property import instance_property
 
@@ -173,6 +172,7 @@ def get_squad_f1(predictions: list, targets: list):
     the f1 of p and each item in t is computed, and the max f1 is used, per the
     squad evaluation standard.
     """
+    from transformers.data.metrics.squad_metrics import compute_f1
 
     def squad_f1_loop(t, p):
         if isinstance(t, list):

--- a/evaluation/utils/evaluator_decen.py
+++ b/evaluation/utils/evaluator_decen.py
@@ -11,10 +11,9 @@ from datetime import datetime
 import boto3
 import botocore
 from dateutil.tz import tzlocal
-
 from utils.helpers import (
-    api_model_endpoint_name,
     api_model_eval_update,
+    api_model_info,
     generate_job_name,
     process_aws_metrics,
     round_end_dt,
@@ -30,8 +29,7 @@ class Job:
 
     def __init__(self, model_id, dataset_name, perturb_prefix=None):
         self.model_id = model_id
-        model_endpoint_name = api_model_endpoint_name(model_id)["endpoint_name"]
-        self.endpoint_name = model_endpoint_name
+        self.endpoint_name = api_model_info(model_id)["endpoint_name"]
         self.dataset_name = dataset_name
         self.perturb_prefix = perturb_prefix
         # Generate a temporary name, the scheduler will put a proper timestamp
@@ -89,7 +87,7 @@ class JobScheduler:
         task_identifier = f"{task.id}-{task.task_code}-{task.name}"
 
         if task_identifier not in self._clients[kind]:
-            region = task.aws_region
+            region = self.config.get("sagemaker_region") or task.aws_region
             self._clients[kind][task_identifier] = boto3.client(
                 kind,
                 aws_access_key_id=self.config["aws_access_key_id"],
@@ -134,7 +132,7 @@ class JobScheduler:
             self.dump()
 
     def is_predictions_upload(self, model_id):
-        model_deployment_status = api_model_endpoint_name(model_id)["deployment_status"]
+        model_deployment_status = api_model_info(model_id)["deployment_status"]
         return model_deployment_status == "predictions_upload"
 
     def _set_jobname_with_unique_timestamp(self, job: Job) -> None:

--- a/evaluation/utils/evaluator_decen.py
+++ b/evaluation/utils/evaluator_decen.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import boto3
 import botocore
 from dateutil.tz import tzlocal
+
 from utils.helpers import (
     api_model_eval_update,
     api_model_info,

--- a/evaluation/utils/evaluator_decen.py
+++ b/evaluation/utils/evaluator_decen.py
@@ -82,20 +82,15 @@ class JobScheduler:
         """
         dataset = self.datasets[dataset_name]
         assert kind in self._clients
-        task = dataset.task
+        region = self.config.get("sagemaker_region") or self.config["aws_region"]
+        self._clients[kind] = boto3.client(
+            kind,
+            aws_access_key_id=self.config["aws_access_key_id"],
+            aws_secret_access_key=self.config["aws_secret_access_key"],
+            region_name=region,
+        )
 
-        task_identifier = f"{task.id}-{task.task_code}-{task.name}"
-
-        if task_identifier not in self._clients[kind]:
-            region = self.config.get("sagemaker_region") or task.aws_region
-            self._clients[kind][task_identifier] = boto3.client(
-                kind,
-                aws_access_key_id=self.config["aws_access_key_id"],
-                aws_secret_access_key=self.config["aws_secret_access_key"],
-                region_name=region,
-            )
-
-        return self._clients[kind][task_identifier]
+        return self._clients[kind]
 
     def _load_status(self):
         try:

--- a/evaluation/utils/helpers.py
+++ b/evaluation/utils/helpers.py
@@ -191,7 +191,9 @@ def send_eval_request(
         return True
 
 
-def send_takedown_model_request(model_id, config, s3_uri=None, logger=None, decen=False):
+def send_takedown_model_request(
+    model_id, config, s3_uri=None, logger=None, decen=False
+):
     if not s3_uri:
         s3_uri = ""
     session = boto3.Session(

--- a/evaluation/utils/helpers.py
+++ b/evaluation/utils/helpers.py
@@ -191,7 +191,7 @@ def send_eval_request(
         return True
 
 
-def send_takedown_model_request(model_id, config, s3_uri=None, logger=None):
+def send_takedown_model_request(model_id, config, s3_uri=None, logger=None, decen=False):
     if not s3_uri:
         s3_uri = ""
     session = boto3.Session(
@@ -203,6 +203,12 @@ def send_takedown_model_request(model_id, config, s3_uri=None, logger=None):
 
     queue = sqs.get_queue_by_name(QueueName=config["builder_sqs_queue"])
     msg = {"model_id": model_id, "s3_uri": s3_uri}
+    if decen:
+        # In decentralized mode we need to send more information to the builder
+        model_info = api_model_info(model_id)
+        model_info["deployment_status"] = "failed"
+        msg["model_info"] = json.dumps(model_info)
+        msg["task_info"] = "{}"
     queue.send_message(MessageBody=json.dumps(msg))
     if logger:
         logger.info(f"Sent message to {config['builder_sqs_queue']}: {msg}")
@@ -371,7 +377,7 @@ def api_get_next_job_score_entry(job, prod=False):
     return r.json()
 
 
-def api_model_endpoint_name(model_id, prod=False):
+def api_model_info(model_id, prod=False) -> str:
     data = {"model_id": model_id}
 
     r = requests.get(

--- a/evaluation/utils/requester_decen.py
+++ b/evaluation/utils/requester_decen.py
@@ -6,7 +6,6 @@ import logging
 
 import yaml
 
-from common.config import config
 from utils.computer_decen import MetricsComputer
 from utils.evaluator_decen import JobScheduler
 from utils.helpers import (
@@ -140,7 +139,7 @@ class Requester:
             remaining_evaluating_job_ids = []
             for mid in failed_models:
                 api_model_update(mid, "completed")
-                send_takedown_model_request(model_id=mid, config=config, logger=logger)
+                send_takedown_model_request(model_id=mid, config=self.config, logger=logger, decen=True)
                 for i, job in enumerate(self.scheduler._queued):
                     if job.model_id != mid:
                         remaining_queued_job_ids.append(i)

--- a/evaluation/utils/requester_decen.py
+++ b/evaluation/utils/requester_decen.py
@@ -139,7 +139,9 @@ class Requester:
             remaining_evaluating_job_ids = []
             for mid in failed_models:
                 api_model_update(mid, "completed")
-                send_takedown_model_request(model_id=mid, config=self.config, logger=logger, decen=True)
+                send_takedown_model_request(
+                    model_id=mid, config=self.config, logger=logger, decen=True
+                )
                 for i, job in enumerate(self.scheduler._queued):
                     if job.model_id != mid:
                         remaining_queued_job_ids.append(i)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ spacy
 pyyaml
 textflint
 ujson>=4.2.0
+urllib3[secure]

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,3 @@ spacy
 pyyaml
 textflint
 ujson>=4.2.0
-urllib3[secure]


### PR DESCRIPTION
Hi all this is a set of fixes for the decentralized task.

I'll be OOO next week so I won't have time to follow up on this before May 3rd, but wanted to put it out there so you know it's coming.
I've tried to do only as few changes as possible, but yet we end up with a big PR.

This workarounds a number of issue I had while migrating Flores task to the decentralized setup:

* dynabench.org website is sending build/eval messages to SQS queue on the same region it currently is, so all tasks need to create a queue in us-west-1.
* I've also added a "sagemaker_region" config, because we want to control in which region the Sagemaker job are run. Regions impact hardware available as well as pricing. Previously the `task.aws_region` was used but in decentralized we don't have access to it. So I change the behavior if and only if the "sagemaker_region" key is present in config.
* model_task_bucket: we need to know where to upload the model send by the users from the build server this is a new config field that wasn't documented
* send_takedown_model_request need to send extra model info in the decentralized setting. Also it was called with the wrong config, which was forcing decentralized user to edit common.config for only one key. I now pass eval_config instead.
*  we now need to use https for unauthenticated git clone
* torchserve now requires “nvgpu” to access GPU info. But doesn’t install it automatically:  https://github.com/pytorch/serve/issues/1516
* show how to not use  aws_access_key_id and aws_secret_access_key keys those can be set to None to default to the account/role of the EC2 instance running the server
* hid a few "transformers" imports to not force it on servers that don't need it since it's a big and slow module to install.
* hid a  imports of DatasetModel and TaskModel  since importing will try to connect to the DB