### PR TITLE
Included mlcommons hostname

### DIFF
--- a/api/common/cors.py
+++ b/api/common/cors.py
@@ -45,7 +45,7 @@ def add_cors_headers():
             "www.dynabench.org",
             "beta.dynabench.org",
             "api.dynabench.org",
-            "dynabench.mlcommons.org"
+            "dynabench.mlcommons.org",
         ]
     else:
         valid_hostnames = ["localhost"]

--- a/api/common/cors.py
+++ b/api/common/cors.py
@@ -45,6 +45,7 @@ def add_cors_headers():
             "www.dynabench.org",
             "beta.dynabench.org",
             "api.dynabench.org",
+            "dynabench.mlcommons.org"
         ]
     else:
         valid_hostnames = ["localhost"]


### PR DESCRIPTION
Added the dynabench.mlcommons.org hostname as one of the valid CORS hostnames, to proceed with the transition between Meta and MLCommons.