### PR TITLE
Added change of context when exiting sandbox mode into live mode

### DIFF
--- a/frontends/web/src/common/Annotation/CreateInterface.js
+++ b/frontends/web/src/common/Annotation/CreateInterface.js
@@ -483,15 +483,19 @@ class CreateInterface extends React.Component {
   }
 
   switchLiveMode(checked) {
-    if (checked === true && !this.context.api.loggedIn()) {
-      this.props.history.push(
-        "/register?msg=" +
-          encodeURIComponent(
-            "Please sign up or log in so that you can get credit for your generated examples."
-          ) +
-          "&src=" +
-          encodeURIComponent(`/tasks/${this.state.taskCode}/create`)
-      );
+    if (checked === true) {
+      if (!this.context.api.loggedIn()) {
+        this.props.history.push(
+          "/register?msg=" +
+            encodeURIComponent(
+              "Please sign up or log in so that you can get credit for your generated examples."
+            ) +
+            "&src=" +
+            encodeURIComponent(`/tasks/${this.state.taskCode}/create`)
+        );
+      } else {
+        this.getNewContext();
+      }
     }
     this.setState({ livemode: checked });
   }


### PR DESCRIPTION
When you exit the sandbox, we should change to a new passage. Otherwise, you could just use the sandbox to find model fooling examples, then exit the sandbox to submit them - a strategy which could guarantee you 100% model-fooling rate.

I've made a small change which I think should sort it but I can't test it properly locally. @ktirumalafb could you please quickly test that everything works properly and re-deploy if possible?

Also tagging @douwekiela and @TristanThrush in case this change introduces any unwanted behaviour I may be missing.

Thanks!