### PR TITLE
add support for chrf++ metric

### DIFF
--- a/api/models/task.py
+++ b/api/models/task.py
@@ -173,6 +173,7 @@ class PerfMetricEnum(enum.Enum):
     accuracy = "accuracy"
     sp_bleu = "sp_bleu"
     bleu = "bleu"
+    chrf_pp = "chrf_pp"
     vqa_accuracy = "vqa_accuracy"
     dataperf_f1 = "dataperf_f1"
 
@@ -240,6 +241,15 @@ def verify_bleu_config(config_obj):
     # is a string or string selection
 
 
+def verify_chrf_pp_config(config_obj):
+    prefixed_message = "in chrf_pp config: "
+    assert "reference_name" in config_obj, (
+        prefixed_message + "reference_name must be in config object"
+    )
+    # TODO: could do more verification to ensure that the type of the referenced object
+    # is a string or string selection
+
+
 perf_metric_config_verifiers = {
     PerfMetricEnum.macro_f1.name: verify_macro_f1_config,
     PerfMetricEnum.squad_f1.name: verify_squad_f1_config,
@@ -248,6 +258,7 @@ perf_metric_config_verifiers = {
     PerfMetricEnum.accuracy.name: verify_accuracy_config,
     PerfMetricEnum.sp_bleu.name: verify_sp_bleu_config,
     PerfMetricEnum.bleu.name: verify_bleu_config,
+    PerfMetricEnum.chrf_pp.name: verify_chrf_pp_config,
 }
 
 

--- a/evaluation/metrics/metrics.py
+++ b/evaluation/metrics/metrics.py
@@ -268,7 +268,7 @@ def get_chrf_pp(predictions: list, targets: list):
 
 
 def get_chrf_pp_meta(task=None):
-    return {"unit": "", "pretty_name": "chrf++", "utility_direction": 1, "offset": 0}
+    return {"unit": "", "pretty_name": "ᴄʜʀF++", "utility_direction": 1, "offset": 0}
 
 
 # job_metrics, takes raw job and dataset as input

--- a/evaluation/metrics/metrics.py
+++ b/evaluation/metrics/metrics.py
@@ -258,6 +258,19 @@ def get_sp_bleu_meta(task=None):
     return {"unit": "", "pretty_name": "sp-BLEU", "utility_direction": 1, "offset": 0}
 
 
+def get_chrf_pp(predictions: list, targets: list):
+    """Chrf++ metric.
+
+    Note: word_order=2 is important otherwise we only get chrf
+    """
+    chrf = sacrebleu.corpus_chrf(predictions, [targets], word_order=2)
+    return chrf.score
+
+
+def get_chrf_pp_meta(task=None):
+    return {"unit": "", "pretty_name": "chrf++", "utility_direction": 1, "offset": 0}
+
+
 # job_metrics, takes raw job and dataset as input
 def get_memory_utilization(job, dataset):
     mem = (

--- a/evaluation/metrics/metrics_dicts.py
+++ b/evaluation/metrics/metrics_dicts.py
@@ -12,6 +12,7 @@ eval_metrics_dict = {
     "squad_f1": metrics.get_squad_f1,
     "bleu": metrics.get_bleu,
     "sp_bleu": metrics.get_sp_bleu,
+    "chrf_pp": metrics.get_chrf_pp,
     "vqa_accuracy": metrics.get_vqa_accuracy,
     "dataperf_f1": metrics.get_dataperf_f1,
 }
@@ -32,6 +33,7 @@ metrics_meta_dict = {
     "squad_f1": metrics.get_squad_f1_meta,
     "bleu": metrics.get_bleu_meta,
     "sp_bleu": metrics.get_sp_bleu_meta,
+    "chrf_pp": metrics.get_chrf_pp_meta,
     "memory_utilization": metrics.get_memory_utilization_meta,
     "examples_per_second": metrics.get_examples_per_second_meta,
     "fairness": metrics.get_fairness_meta,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ werkzeug
 boto3
 yoyo-migrations
 pandas==1.3.0
-sacrebleu
+sacrebleu>=2.0.0
 sklearn
 git+https://github.com/facebookresearch/dynalab.git
 sentencepiece


### PR DESCRIPTION
For the WMT22 shared task, we want to use Chrf++ as a metric to evaluate the translation instead of spBLEU like last year.

@vedanuj can you confirm this is the correct way of computing Chrf++ (In particular we don't explicitly do tokenization) ?

@TristanThrush  can you help me figure out if this is the only thing that need to be added for new metrics ?

When creating a new task Dynabench seems to compare the "perf_metric" to a list of accepted metrics. Where is this list ?
Does that mean we need to upgrade Dynabench before I can create the new task ?